### PR TITLE
Change address part delimiter

### DIFF
--- a/bldg_server/lib/bldg_server/buildings.ex
+++ b/bldg_server/lib/bldg_server/buildings.ex
@@ -130,12 +130,12 @@ defmodule BldgServer.Buildings do
   # UTILS
 
   def extract_coords(addr) do
-    # get the last part of the address: "g/b(17,24)/l0/b(11,6)" -> "b(11,6)"
-    coords_token = addr
+    # get the coords from the last part of the address: "g/b(17,24)/l0/b(-11,6)" -> ["-11","6]
+    [x_s, y_s] = addr
     |> String.split(address_delimiter)
     |> List.last()
-    # get the coordinates: "b(11,6)" -> (11,6)
-    [[x_s], [y_s]] = Regex.scan(~r{\d+}, coords_token)
+    |> String.slice(2..-2)
+    |> String.split(",")
     {{x, ""}, {y, ""}} = {Integer.parse(x_s), Integer.parse(y_s)}
     {x, y}
   end

--- a/bldg_server/lib/bldg_server/buildings.ex
+++ b/bldg_server/lib/bldg_server/buildings.ex
@@ -8,6 +8,9 @@ defmodule BldgServer.Buildings do
 
   alias BldgServer.Buildings.Bldg
 
+
+  def address_delimiter, do: "/"
+
   @doc """
   Returns the list of bldgs.
 
@@ -127,9 +130,9 @@ defmodule BldgServer.Buildings do
   # UTILS
 
   def extract_coords(addr) do
-    # get the last part of the address: "g-b(17,24)-l0-b(11,6)" -> "b(11,6)"
+    # get the last part of the address: "g/b(17,24)/l0/b(11,6)" -> "b(11,6)"
     coords_token = addr
-    |> String.split("-")
+    |> String.split(address_delimiter)
     |> List.last()
     # get the coordinates: "b(11,6)" -> (11,6)
     [[x_s], [y_s]] = Regex.scan(~r{\d+}, coords_token)

--- a/bldg_server/lib/bldg_server/residents.ex
+++ b/bldg_server/lib/bldg_server/residents.ex
@@ -139,7 +139,7 @@ defmodule BldgServer.Residents do
 
   ## Examples
 
-      iex> move(resident, "g-b(14, 25)", 14, 25)
+      iex> move(resident, "g/b(14, 25)", 14, 25)
       {:ok, %Resident{}}
 
   """

--- a/bldg_server/lib/bldg_server_web/controllers/bldg_controller.ex
+++ b/bldg_server/lib/bldg_server_web/controllers/bldg_controller.ex
@@ -52,7 +52,7 @@ defmodule BldgServerWeb.BldgController do
         %{"container_web_url" => container} = entity
         entity_bldg = Buildings.get_by_web_url(container)
         # TODO handle the case the container bldg doesn't exist
-        "#{entity_bldg.address}-l0"
+        "#{entity_bldg.address}#{Buildings.address_delimiter}l0"
       Map.has_key?(entity, "flr") ->
         Map.get(entity, "flr")
       true -> "g"
@@ -148,8 +148,8 @@ Given an entity:
     }
     Creates a building matching the entity, e.g.:
     "bldg": {
-      "address": "g-b(17,24)-l0-b(55,135)",
-      "flr": "g-b(17,24)-l0",
+      "address": "g/b(17,24)/l0/b(55,135)",
+      "flr": "g/b(17,24)/l0",
       "x": 55,
       "y": 135,
       "is_composite": false,

--- a/bldg_server/test/bldg_server/buildings_test.exs
+++ b/bldg_server/test/bldg_server/buildings_test.exs
@@ -6,7 +6,7 @@ defmodule BldgServer.BuildingsTest do
   describe "bldgs" do
     alias BldgServer.Buildings.Bldg
 
-    @addr "g-b(1,2)-l0"
+    @addr "g/b(1,2)/l0"
     @valid_attrs %{address: @addr, category: "some category", data: %{}, entity_type: "some entity_type", flr: "some flr", is_composite: true, name: "some name", picture_url: "some picture_url", state: "some state", summary: "some summary", tags: [], web_url: "some web_url", x: 42, y: 42}
     @update_attrs %{address: "some updated address", category: "some updated category", data: %{}, entity_type: "some updated entity_type", flr: "some updated flr", is_composite: false, name: "some updated name", picture_url: "some updated picture_url", state: "some updated state", summary: "some updated summary", tags: [], web_url: "some updated web_url", x: 43, y: 43}
     @invalid_attrs %{address: nil, category: nil, data: nil, entity_type: nil, flr: nil, is_composite: nil, name: nil, picture_url: nil, state: nil, summary: nil, tags: nil, web_url: nil, x: nil, y: nil}

--- a/bldg_server/test/bldg_server_web/controllers/bldg_controller_test.exs
+++ b/bldg_server/test/bldg_server_web/controllers/bldg_controller_test.exs
@@ -8,7 +8,7 @@ defmodule BldgServerWeb.BldgControllerTest do
 
 
   @create_attrs %{
-    address: "g-b(1,2)-l0",
+    address: "g/b(1,2)/l0",
     category: "some category",
     data: %{},
     entity_type: "some entity_type",
@@ -24,7 +24,7 @@ defmodule BldgServerWeb.BldgControllerTest do
     y: 42
   }
   @update_attrs %{
-    address: "g-b(5,6)-l0",
+    address: "g/b(5,6)/l0",
     category: "some updated category",
     data: %{},
     entity_type: "some updated entity_type",
@@ -66,7 +66,7 @@ defmodule BldgServerWeb.BldgControllerTest do
 
       assert %{
                "id" => id,
-               "address" => "g-b(1,2)-l0",
+               "address" => "g/b(1,2)/l0",
                "category" => "some category",
                "data" => %{},
                "entity_type" => "some entity_type",
@@ -95,16 +95,16 @@ defmodule BldgServerWeb.BldgControllerTest do
     test "renders bldg when data is valid", %{conn: conn, bldg: %Bldg{address: address} = bldg} do
       # TODO bldg_path doesn't return the right URL: it doesn't use the address instead of the id
       #conn = put(conn, Routes.bldg_path(conn, :update, bldg), bldg: @update_attrs)
-      url = "/v1/bldgs/g-b(1,2)-l0"
+      url = "/v1/bldgs/g/b(1,2)/l0"
       conn = put(conn, url, bldg: @update_attrs)
-      assert %{"address" => "g-b(5,6)-l0"} = json_response(conn, 200)["data"]
+      assert %{"address" => "g/b(5,6)/l0"} = json_response(conn, 200)["data"]
 
-      new_url = "/v1/bldgs/g-b(5,6)-l0"
+      new_url = "/v1/bldgs/g/b(5,6)/l0"
       conn = get(conn, new_url)
 
       assert %{
                "id" => id,
-               "address" => "g-b(5,6)-l0",
+               "address" => "g/b(5,6)/l0",
                "category" => "some updated category",
                "data" => %{},
                "entity_type" => "some updated entity_type",
@@ -124,7 +124,7 @@ defmodule BldgServerWeb.BldgControllerTest do
     test "renders errors when data is invalid", %{conn: conn, bldg: bldg} do
       # TODO bldg_path doesn't return the right URL: it doesn't use the address instead of the id
       #conn = put(conn, Routes.bldg_path(conn, :update, bldg), bldg: @invalid_attrs)
-      url = "/v1/bldgs/g-b(1,2)-l0"
+      url = "/v1/bldgs/g/b(1,2)/l0"
       conn = put(conn, url, bldg: @invalid_attrs)
       assert json_response(conn, 422)["errors"] != %{}
     end
@@ -136,7 +136,7 @@ defmodule BldgServerWeb.BldgControllerTest do
     test "deletes chosen bldg", %{conn: conn, bldg: bldg} do
       # TODO bldg_path doesn't return the right URL: it doesn't use the address instead of the id
       #conn = delete(conn, Routes.bldg_path(conn, :delete, bldg))
-      url = "/v1/bldgs/g-b(1,2)-l0"
+      url = "/v1/bldgs/g/b(1,2)/l0"
       conn = delete(conn, url)
       assert response(conn, 204)
 

--- a/bldg_server/test/bldg_server_web/controllers/resident_controller_test.exs
+++ b/bldg_server/test/bldg_server_web/controllers/resident_controller_test.exs
@@ -11,8 +11,8 @@ defmodule BldgServerWeb.ResidentControllerTest do
     home_bldg: "some home_bldg",
     is_online: false,
     last_login_at: ~N[2010-04-17 14:00:00],
-    location: "g-b(17,24)-l0-b(4,5)",
-    flr: "g-b(17,24)-l0",
+    location: "g/b(17,24)/l0/b(4,5)",
+    flr: "g/b(17,24)/l0",
     name: "some name",
     other_attributes: %{},
     previous_messages: [],
@@ -25,8 +25,8 @@ defmodule BldgServerWeb.ResidentControllerTest do
     home_bldg: "some updated home_bldg",
     is_online: true,
     last_login_at: ~N[2011-05-18 15:01:01],
-    location: "g-b(17,24)-l0-b(6,8)",
-    flr: "g-b(17,24)-l0",
+    location: "g/b(17,24)/l0/b(6,8)",
+    flr: "g/b(17,24)/l0",
     name: "some updated name",
     other_attributes: %{},
     previous_messages: [],
@@ -65,8 +65,8 @@ defmodule BldgServerWeb.ResidentControllerTest do
                "home_bldg" => "some home_bldg",
                "is_online" => false,
                "last_login_at" => "2010-04-17T14:00:00",
-               "location" => "g-b(17,24)-l0-b(4,5)",
-               "flr" => "g-b(17,24)-l0",
+               "location" => "g/b(17,24)/l0/b(4,5)",
+               "flr" => "g/b(17,24)/l0",
                "name" => "some name",
                "other_attributes" => %{},
                "previous_messages" => [],
@@ -97,8 +97,8 @@ defmodule BldgServerWeb.ResidentControllerTest do
                "home_bldg" => "some updated home_bldg",
                "is_online" => true,
                "last_login_at" => "2011-05-18T15:01:01",
-               "location" => "g-b(17,24)-l0-b(6,8)",
-               "flr" => "g-b(17,24)-l0",
+               "location" => "g/b(17,24)/l0/b(6,8)",
+               "flr" => "g/b(17,24)/l0",
                "name" => "some updated name",
                "other_attributes" => %{},
                "previous_messages" => [],
@@ -129,8 +129,8 @@ defmodule BldgServerWeb.ResidentControllerTest do
                "home_bldg" => "some home_bldg",
                "is_online" => true,
                "last_login_at" => expected_last_login,
-               "location" => "g-b(17,24)-l0-b(4,5)",
-               "flr" => "g-b(17,24)-l0",
+               "location" => "g/b(17,24)/l0/b(4,5)",
+               "flr" => "g/b(17,24)/l0",
                "name" => "some name",
                "other_attributes" => %{},
                "previous_messages" => [],
@@ -144,7 +144,7 @@ defmodule BldgServerWeb.ResidentControllerTest do
     setup [:create_resident]
 
     test "resident moves when action data is valid", %{conn: conn, resident: %Resident{id: id} = resident} do
-      conn = post(conn, "/v1/residents/act", %{"resident_email" => "some email", "action_type" => "MOVE", "move_location" => "g-b(17,24)-l0-b(10,15)", "move_x" => 10, "move_y" => 15})
+      conn = post(conn, "/v1/residents/act", %{"resident_email" => "some email", "action_type" => "MOVE", "move_location" => "g/b(17,24)/l0/b(10,15)", "move_x" => 10, "move_y" => 15})
       assert %{"id" => ^id} = json_response(conn, 200)["data"]
 
       conn = get(conn, Routes.resident_path(conn, :show, id))
@@ -157,10 +157,10 @@ defmodule BldgServerWeb.ResidentControllerTest do
                "home_bldg" => "some home_bldg",
                "is_online" => false,
                "last_login_at" => expected_last_login,
-               "location" => "g-b(17,24)-l0-b(10,15)",
+               "location" => "g/b(17,24)/l0/b(10,15)",
                "x" => 10,
                "y" => 15,
-               "flr" => "g-b(17,24)-l0",
+               "flr" => "g/b(17,24)/l0",
                "name" => "some name",
                "other_attributes" => %{},
                "previous_messages" => [],


### PR DESCRIPTION
## Why
The original bldg address schema had `-` as the delimiter between the address parts. This caused issues when an address part had a negative number (e.g., `g-b(-123,456)`), for naiive address parsers that split the address by the `-` delimiter (such as the parsers I created..)

## What
Changing the bldg address schema to use `/` as the parts delimiter, e.g.:
`g-b(123,456)-l0-b(30,10)-l2` -> `g/b(123,456)/l0/b(30,10)/l2`

## Possible issues
Sometimes a web URL contains a bldg address, which will now blend with the URL path, e.g.:
`https://api.w2m.site/v1/bldgs/look/g/b(123,456)/l0`