### PR TITLE
add turn action

### DIFF
--- a/bldg_server/config/dev.exs
+++ b/bldg_server/config/dev.exs
@@ -2,8 +2,8 @@ use Mix.Config
 
 # Configure your database
 config :bldg_server, BldgServer.Repo,
-  username: "postgres",
-  password: "postgres",
+  username: "udi",
+  password: "",
   database: "bldg_server_dev",
   hostname: "localhost",
   show_sensitive_data_on_connection_error: true,

--- a/bldg_server/config/dev.exs
+++ b/bldg_server/config/dev.exs
@@ -2,8 +2,8 @@ use Mix.Config
 
 # Configure your database
 config :bldg_server, BldgServer.Repo,
-  username: "udi",
-  password: "",
+  username: "postgres",
+  password: "postgres",
   database: "bldg_server_dev",
   hostname: "localhost",
   show_sensitive_data_on_connection_error: true,

--- a/bldg_server/lib/bldg_server/residents.ex
+++ b/bldg_server/lib/bldg_server/residents.ex
@@ -148,6 +148,10 @@ defmodule BldgServer.Residents do
     update_resident(resident, changes)
   end
 
+  def change_dir(%Resident{} = resident, direction) do
+    changes = %{direction: direction}
+    update_resident(resident, changes)
+  end
 
   def append_message_to_list(msg_list, msg) do
     case msg_list do

--- a/bldg_server/lib/bldg_server_web/controllers/resident_controller.ex
+++ b/bldg_server/lib/bldg_server_web/controllers/resident_controller.ex
@@ -74,6 +74,18 @@ defmodule BldgServerWeb.ResidentController do
       |> render("show.json", resident: resident)
     end
   end
+
+  # TURN action
+  def act(conn, %{"resident_email" => email, "action_type" => "TURN", "turn_direction" => direction}) do
+    resident = Residents.get_resident_by_email!(email)
+
+    with {:ok, %Resident{}} <- Residents.change_dir(resident, direction) do
+      conn
+      |> put_status(:ok)
+      |> put_resp_header("location", Routes.resident_path(conn, :show, resident))
+      |> render("show.json", resident: resident)
+    end
+  end
   
   # SAY action
   def act(conn, %{"resident_email" => email, "action_type" => "SAY", "say_speaker" => speaker, "say_text" => text, "say_time" => msg_time, "say_flr" => flr, "say_location" => location, "say_mimetype" => msg_mimetype, "say_recipient" => recipient} = msg) do


### PR DESCRIPTION
## Why
Residents should be able to turn & other residents should see that they're turning

## What
Added a turn action that sends the current rotation of the resident to be updated on the resident record.
The action is invoked not on every rotation, but only in intervals of `20` degrees, in order not to overload the bldg server.