### PR TITLE
Remember me

### DIFF
--- a/bldg_server/lib/bldg_server/residents_auth.ex
+++ b/bldg_server/lib/bldg_server/residents_auth.ex
@@ -52,6 +52,15 @@ defmodule BldgServer.ResidentsAuth do
     Repo.get_by(Session, session_id: session_id)
   end
 
+  def get_most_recent_verified_session(resident_id, ip_address) do
+    verified_status = verified()
+    # lookup a session with verified status & the given resident_id & ip_address
+    # TODO add migration to create the corresponding index in the DB
+    query = from s in "sessions",
+      where: s.resident_id == ^resident_id and s.ip_address == ^ip_address and s.status == ^verified_status,
+      select: {s.session_id, s.updated_at}
+    Repo.all(last(query, :updated_at))
+  end
 
   @doc """
   Creates a session.

--- a/bldg_server/lib/utils.ex
+++ b/bldg_server/lib/utils.ex
@@ -1,0 +1,7 @@
+defmodule Utils do
+
+  def is_older_than_x_minutes_ago(dt, x), do: NaiveDateTime.diff(NaiveDateTime.utc_now(), dt) > (x * 60)
+
+  def is_newer_than_x_minutes_ago(dt, x), do: NaiveDateTime.diff(NaiveDateTime.utc_now(), dt) < (x * 60)
+
+end


### PR DESCRIPTION
## Why
Verifying email upon login is important, but if the user did it recently, & still uses the same IP address, we can bypass the email verification (until we decide otherwise). 


## What
* Bypass the email verification in case it was successfully done in the last 7 days, & the IP address is the same

## Left to do
* This implementation has a lot of room for improvement, in the way it indicates to the client that email verification was bypassed