### PR TITLE
Enter bldgs

### DIFF
--- a/bldg_server/config/dev.exs
+++ b/bldg_server/config/dev.exs
@@ -2,8 +2,8 @@ use Mix.Config
 
 # Configure your database
 config :bldg_server, BldgServer.Repo,
-  username: "postgres",
-  password: "postgres",
+  username: "udi",
+  password: "",
   database: "bldg_server_dev",
   hostname: "localhost",
   show_sensitive_data_on_connection_error: true,

--- a/bldg_server/lib/bldg_server/buildings.ex
+++ b/bldg_server/lib/bldg_server/buildings.ex
@@ -140,6 +140,10 @@ defmodule BldgServer.Buildings do
     {x, y}
   end
 
+  def move_from_speaker({x, y}, offset) do
+    {x, y + offset}
+  end
+
   def get_container_flr(addr) do
     # returns the container flr for given address. TODO verify that a bldg is given & not a flr
     addr

--- a/bldg_server/lib/bldg_server/buildings.ex
+++ b/bldg_server/lib/bldg_server/buildings.ex
@@ -140,6 +140,16 @@ defmodule BldgServer.Buildings do
     {x, y}
   end
 
+  def get_container_flr(addr) do
+    # returns the container flr for given address. TODO verify that a bldg is given & not a flr
+    addr
+    |> String.split(address_delimiter)
+    |> Enum.reverse()
+    |> tl()
+    |> Enum.reverse()
+    |> Enum.join(address_delimiter)
+  end
+
 
   # FRAMEWORK
 

--- a/bldg_server/lib/bldg_server/residents.ex
+++ b/bldg_server/lib/bldg_server/residents.ex
@@ -103,6 +103,9 @@ defmodule BldgServer.Residents do
     resident
     |> Resident.changeset(attrs)
     |> Repo.update()
+    IO.puts("~~~~~~~~~~~~~~~~~")
+    IO.inspect(resident)
+    resident
   end
 
   @doc """
@@ -185,7 +188,7 @@ defmodule BldgServer.Residents do
   end
 
   def enter_bldg(%Resident{} = resident, address) do
-    changes = %{flr: "#{address}/l0", location: "#{address}/l0/b(10,10)", x: 10, y: 10}
+    changes = %{flr: "#{address}/l0", location: "#{address}/l0/b(0,30)", x: 0, y: 30}
     update_resident(resident, changes)
   end
 

--- a/bldg_server/lib/bldg_server/residents.ex
+++ b/bldg_server/lib/bldg_server/residents.ex
@@ -103,9 +103,6 @@ defmodule BldgServer.Residents do
     resident
     |> Resident.changeset(attrs)
     |> Repo.update()
-    IO.puts("~~~~~~~~~~~~~~~~~")
-    IO.inspect(resident)
-    resident
   end
 
   @doc """

--- a/bldg_server/lib/bldg_server/residents.ex
+++ b/bldg_server/lib/bldg_server/residents.ex
@@ -150,7 +150,7 @@ defmodule BldgServer.Residents do
     ip_addr = conn.remote_ip |> :inet_parse.ntoa |> to_string()
     # check whether the resident has a verified session, from the same ip address, in the last week
     recent_session = ResidentsAuth.get_most_recent_verified_session(resident.id, ip_addr)
-    if recent_session == nil do
+    if recent_session == [] do
       start_email_verification(resident, ip_addr)
     else
       [{session_id, updated_at}] = recent_session

--- a/bldg_server/lib/bldg_server/residents.ex
+++ b/bldg_server/lib/bldg_server/residents.ex
@@ -185,7 +185,7 @@ defmodule BldgServer.Residents do
   end
 
   def enter_bldg(%Resident{} = resident, address) do
-    changes = %{flr: "#{address}/l0", location: "#{address}/l0/b(0,30)", x: 0, y: 30}
+    changes = %{flr: "#{address}/l0", location: "#{address}/l0/b(0,33)", x: 0, y: 33}
     update_resident(resident, changes)
   end
 

--- a/bldg_server/lib/bldg_server/residents.ex
+++ b/bldg_server/lib/bldg_server/residents.ex
@@ -9,7 +9,8 @@ defmodule BldgServer.Residents do
   alias BldgServer.Residents.Resident
   alias BldgServer.ResidentsAuth
 
-  alias BldgServerWeb.Router.Helpers, as: Routes
+  # alias BldgServerWeb.Router.Helpers, as: Routes
+
 
   @doc """
   Returns the list of residents.

--- a/bldg_server/lib/bldg_server/residents.ex
+++ b/bldg_server/lib/bldg_server/residents.ex
@@ -8,6 +8,8 @@ defmodule BldgServer.Residents do
 
   alias BldgServer.Residents.Resident
   alias BldgServer.ResidentsAuth
+  alias BldgServer.Buildings
+
 
   # alias BldgServerWeb.Router.Helpers, as: Routes
 
@@ -189,6 +191,18 @@ defmodule BldgServer.Residents do
     update_resident(resident, changes)
   end
 
+  def exit_bldg(%Resident{} = resident, address) do
+    # get the container flr
+    container_flr = Buildings.get_container_flr(address)
+
+    # determine the location next to the door of the bldg exited
+    {x, y} = Buildings.extract_coords(address)
+    new_x = x
+    new_y = y + 6
+
+    changes = %{flr: container_flr, location: "#{container_flr}/b(#{new_x},#{new_y})", x: new_x, y: new_y}
+    update_resident(resident, changes)
+  end
 
   def change_dir(%Resident{} = resident, direction) do
     changes = %{direction: direction}

--- a/bldg_server/lib/bldg_server/residents.ex
+++ b/bldg_server/lib/bldg_server/residents.ex
@@ -187,7 +187,8 @@ defmodule BldgServer.Residents do
   end
 
   def enter_bldg(%Resident{} = resident, address) do
-    changes = %{flr: "#{address}/l0", location: "#{address}/l0/b(0,33)", x: 0, y: 33}
+    {initial_x, initial_y} = {8, 40}  # TODO read from config, per bldg type
+    changes = %{flr: "#{address}/l0", location: "#{address}/l0/b(#{initial_x},#{initial_y})", x: initial_x, y: initial_y}
     update_resident(resident, changes)
   end
 

--- a/bldg_server/lib/bldg_server/residents.ex
+++ b/bldg_server/lib/bldg_server/residents.ex
@@ -184,6 +184,12 @@ defmodule BldgServer.Residents do
     update_resident(resident, changes)
   end
 
+  def enter_bldg(%Resident{} = resident, address) do
+    changes = %{flr: "#{address}/l0", location: "#{address}/l0/b(10,10)", x: 10, y: 10}
+    update_resident(resident, changes)
+  end
+
+
   def change_dir(%Resident{} = resident, direction) do
     changes = %{direction: direction}
     update_resident(resident, changes)

--- a/bldg_server/lib/bldg_server_web/bldg_command_executor.ex
+++ b/bldg_server/lib/bldg_server_web/bldg_command_executor.ex
@@ -84,7 +84,7 @@ defmodule BldgServerWeb.BldgCommandExecutor do
 
         # TODO if creating under a given bldg, send its container_web_url instead of flr
 
-        {x, y} = Buildings.extract_coords(msg["say_location"])
+        {x, y} = Buildings.extract_coords(msg["say_location"]) |> Buildings.move_from_speaker(-10)
         entity = %{
           "flr" => msg["say_flr"],
           "address" => msg["say_location"],
@@ -108,7 +108,7 @@ defmodule BldgServerWeb.BldgCommandExecutor do
 
       # TODO if creating under a given bldg, send its container_web_url instead of flr
 
-      {x, y} = Buildings.extract_coords(msg["say_location"])
+      {x, y} = Buildings.extract_coords(msg["say_location"]) |> Buildings.move_from_speaker(-10)
       entity = %{
         "flr" => msg["say_flr"],
         "address" => msg["say_location"],
@@ -132,7 +132,7 @@ defmodule BldgServerWeb.BldgCommandExecutor do
 
       # TODO if creating under a given bldg, send its container_web_url instead of flr
 
-      {x, y} = Buildings.extract_coords(msg["say_location"])
+      {x, y} = Buildings.extract_coords(msg["say_location"]) |> Buildings.move_from_speaker(-10)
       entity = %{
         "flr" => msg["say_flr"],
         "address" => msg["say_location"],
@@ -156,7 +156,7 @@ defmodule BldgServerWeb.BldgCommandExecutor do
 
         # TODO if creating under a given bldg, send its container_web_url instead of flr
 
-        {x, y} = Buildings.extract_coords(msg["say_location"])
+        {x, y} = Buildings.extract_coords(msg["say_location"]) |> Buildings.move_from_speaker(-10)
         entity = %{
           "flr" => msg["say_flr"],
           "address" => msg["say_location"],

--- a/bldg_server/lib/bldg_server_web/controllers/bldg_controller.ex
+++ b/bldg_server/lib/bldg_server_web/controllers/bldg_controller.ex
@@ -42,7 +42,9 @@ defmodule BldgServerWeb.BldgController do
   end
 
   def look(conn, %{"flr" => flr}) do
-    bldgs = Buildings.list_bldgs_in_flr(flr)
+    # unescape the flr parameter
+    decoded_flr = URI.decode(flr)
+    bldgs = Buildings.list_bldgs_in_flr(decoded_flr)
     render(conn, "look.json", bldgs: bldgs)
   end
 

--- a/bldg_server/lib/bldg_server_web/controllers/bldg_controller.ex
+++ b/bldg_server/lib/bldg_server_web/controllers/bldg_controller.ex
@@ -21,7 +21,9 @@ defmodule BldgServerWeb.BldgController do
   end
 
   def show(conn, %{"address" => address}) do
-    bldg = Buildings.get_bldg!(address)
+    # unescape the address parameter
+    decoded_address = URI.decode(address)
+    bldg = Buildings.get_bldg!(decoded_address)
     render(conn, "show.json", bldg: bldg)
   end
 

--- a/bldg_server/lib/bldg_server_web/controllers/resident_controller.ex
+++ b/bldg_server/lib/bldg_server_web/controllers/resident_controller.ex
@@ -124,11 +124,11 @@ defmodule BldgServerWeb.ResidentController do
     resident = Residents.get_resident_by_email!(email)
     # TODO validate that the new location is free
 
-    with {:ok, %Resident{}} <- Residents.move(resident, location, x, y) do
+    with {:ok, %Resident{} = upd_rsdt} <- Residents.move(resident, location, x, y) do
       conn
       |> put_status(:ok)
-      |> put_resp_header("location", Routes.resident_path(conn, :show, resident))
-      |> render("show.json", resident: resident)
+      |> put_resp_header("location", Routes.resident_path(conn, :show, upd_rsdt))
+      |> render("show.json", resident: upd_rsdt)
     end
   end
 
@@ -136,11 +136,11 @@ defmodule BldgServerWeb.ResidentController do
   def act(conn, %{"resident_email" => email, "action_type" => "TURN", "turn_direction" => direction}) do
     resident = Residents.get_resident_by_email!(email)
 
-    with {:ok, %Resident{}} <- Residents.change_dir(resident, direction) do
+    with {:ok, %Resident{} = upd_rsdt} <- Residents.change_dir(resident, direction) do
       conn
       |> put_status(:ok)
-      |> put_resp_header("location", Routes.resident_path(conn, :show, resident))
-      |> render("show.json", resident: resident)
+      |> put_resp_header("location", Routes.resident_path(conn, :show, upd_rsdt))
+      |> render("show.json", resident: upd_rsdt)
     end
   end
 
@@ -148,11 +148,11 @@ defmodule BldgServerWeb.ResidentController do
   def act(conn, %{"resident_email" => email, "action_type" => "SAY", "say_speaker" => _speaker, "say_text" => _text, "say_time" => _msg_time, "say_flr" => _flr, "say_location" => _location, "say_mimetype" => _msg_mimetype, "say_recipient" => _recipient} = msg) do
     resident = Residents.get_resident_by_email!(email)
 
-    with {:ok, %Resident{}} <- Residents.say(resident, msg) do
+    with {:ok, %Resident{} = upd_rsdt} <- Residents.say(resident, msg) do
       conn
       |> put_status(:ok)
-      |> put_resp_header("location", Routes.resident_path(conn, :show, resident))
-      |> render("show.json", resident: resident)
+      |> put_resp_header("location", Routes.resident_path(conn, :show, upd_rsdt))
+      |> render("show.json", resident: upd_rsdt)
     end
   end
 
@@ -161,11 +161,11 @@ defmodule BldgServerWeb.ResidentController do
     resident = Residents.get_resident_by_email!(email)
     # TODO validate that the resident is authorized to enter the given bldg
 
-    with {:ok, %Resident{}} <- Residents.enter_bldg(resident, address) do
+    with {:ok, %Resident{} = upd_rsdt} <- Residents.enter_bldg(resident, address) do
       conn
       |> put_status(:ok)
-      |> put_resp_header("location", Routes.resident_path(conn, :show, resident))
-      |> render("show.json", resident: resident)
+      |> put_resp_header("location", Routes.resident_path(conn, :show, upd_rsdt))
+      |> render("show.json", resident: upd_rsdt)
     end
   end
 end

--- a/bldg_server/lib/bldg_server_web/controllers/resident_controller.ex
+++ b/bldg_server/lib/bldg_server_web/controllers/resident_controller.ex
@@ -154,4 +154,16 @@ defmodule BldgServerWeb.ResidentController do
     end
   end
 
+  # ENTER_BLDG action
+  def act(conn, %{"resident_email" => email, "action_type" => "ENTER_BLDG", "bldg_address" => address}) do
+    resident = Residents.get_resident_by_email!(email)
+    # TODO validate that the resident is authorized to enter the given bldg
+
+    with {:ok, %Resident{}} <- Residents.enter_bldg(resident, address) do
+      conn
+      |> put_status(:ok)
+      |> put_resp_header("location", Routes.resident_path(conn, :show, resident))
+      |> render("show.json", resident: resident)
+    end
+  end
 end

--- a/bldg_server/lib/bldg_server_web/controllers/resident_controller.ex
+++ b/bldg_server/lib/bldg_server_web/controllers/resident_controller.ex
@@ -168,4 +168,18 @@ defmodule BldgServerWeb.ResidentController do
       |> render("show.json", resident: upd_rsdt)
     end
   end
+
+  # EXIT_BLDG action
+  def act(conn, %{"resident_email" => email, "action_type" => "EXIT_BLDG", "bldg_address" => address}) do
+    resident = Residents.get_resident_by_email!(email)
+    # TODO validate that the resident is authorized to enter the container bldg (although if not, are they essentially locked?)
+
+    with {:ok, %Resident{} = upd_rsdt} <- Residents.exit_bldg(resident, address) do
+      conn
+      |> put_status(:ok)
+      |> put_resp_header("location", Routes.resident_path(conn, :show, upd_rsdt))
+      |> render("show.json", resident: upd_rsdt)
+    end
+  end
+
 end

--- a/bldg_server/lib/bldg_server_web/controllers/resident_controller.ex
+++ b/bldg_server/lib/bldg_server_web/controllers/resident_controller.ex
@@ -110,7 +110,9 @@ defmodule BldgServerWeb.ResidentController do
   end
 
   def look(conn, %{"flr" => flr}) do
-    residents = Residents.list_residents_in_flr(flr)
+    # unescape the flr parameter
+    decoded_flr = URI.decode(flr)
+    residents = Residents.list_residents_in_flr(decoded_flr)
     render(conn, "look.json", residents: residents)
   end
 

--- a/bldg_server/lib/bldg_server_web/controllers/road_controller.ex
+++ b/bldg_server/lib/bldg_server_web/controllers/road_controller.ex
@@ -42,7 +42,9 @@ defmodule BldgServerWeb.RoadController do
   end
 
   def look(conn, %{"flr" => flr}) do
-    roads = Relations.list_roads_in_flr(flr)
+    # unescape the flr parameter
+    decoded_flr = URI.decode(flr)
+    roads = Relations.list_roads_in_flr(decoded_flr)
     render(conn, "look.json", roads: roads)
   end
 

--- a/bldg_server/mix.exs
+++ b/bldg_server/mix.exs
@@ -4,7 +4,7 @@ defmodule BldgServer.MixProject do
   def project do
     [
       app: :bldg_server,
-      version: "0.4.5",
+      version: "0.4.7",
       elixir: "~> 1.5",
       elixirc_paths: elixirc_paths(Mix.env()),
       compilers: [:phoenix, :gettext] ++ Mix.compilers(),


### PR DESCRIPTION
## Why
Allow residents to properly enter & exit bldgs (not just walk thru them), so that residents will be able to perceive the content of a bldg & be subject to the authorization of that bldg.


## What
* Added `owners` list to every bldg
* Added `ENTER_BLDG` & `EXIT_BLDG` resident actions (invoked thru the regular act API)
* Alas, the addresses of nested bldgs don't work well with the router, requiring the client to encode the address