### PR TITLE
New syntax for the command for connecting bldgs

### DIFF
--- a/bldg_server/lib/bldg_server_web/bldg_command_executor.ex
+++ b/bldg_server/lib/bldg_server_web/bldg_command_executor.ex
@@ -52,8 +52,9 @@ defmodule BldgServerWeb.BldgCommandExecutor do
       end
     end
 
-    # create road between 2 bldgs (given using their websites)
-    def execute_command(["/create", "road", "between", website1, "and", website2], msg) do
+    # create road between 2 bldgs (using their websites)
+    # TODO handle the case where there are multiple bldgs for the same website - check the ones owned by the user in order to resolve
+    def execute_command(["/connect", "between", website1, "and", website2], msg) do
         # create a road between the given bldgs, inside the given flr
 
         # validate that the actor resident/bldg has the sufficient permissions


### PR DESCRIPTION
## Why
Simplify the commands syntax - distinguish between commands for creating bldgs & the command for connecting bldgs

## What
changed the syntax of the chat command to connect 2 bldgs: previously it was:
`create road between <bldg 1 url> and <bldg 2 url>` 
 & after this change the syntax is:
`connect between <bldg 1 url> and <bldg 2 url>`