### PR TITLE
[WIP] Bldg url

### DIFF
--- a/bldg_server/.gitignore
+++ b/bldg_server/.gitignore
@@ -26,6 +26,7 @@ bldg_server-*.tar
 # we ignore priv/static. You may want to comment
 # this depending on your deployment strategy.
 /priv/static/
+/priv/cert
 
 .env
 .env-stack

--- a/bldg_server/lib/bldg_server/buildings.ex
+++ b/bldg_server/lib/bldg_server/buildings.ex
@@ -314,7 +314,6 @@ Given an entity:
     |> Enum.drop(1) |> length()
     depth = case num_slashes do
       0 -> 0
-      1 -> 1
       _ -> (num_slashes + 1) / 2
     end
     Map.put(entity, "nesting_depth", depth)

--- a/bldg_server/lib/bldg_server/buildings.ex
+++ b/bldg_server/lib/bldg_server/buildings.ex
@@ -143,10 +143,10 @@ defmodule BldgServer.Buildings do
   end
 
   def extract_flr_level(flr) do
-    l_s = flr
-    |> String.split(address_delimiter)
-    |> List.last()
-    |> String.slice(1..-1)
+    l_s = case flr do
+      "g" -> "0"
+      _ -> flr |> String.split(address_delimiter) |> List.last() |> String.slice(1..-1)
+    end
     {level, ""} = Integer.parse(l_s)
     level
   end
@@ -212,7 +212,7 @@ defmodule BldgServer.Buildings do
         entity_bldg = Buildings.get_by_bldg_url(container)
         {"#{entity_bldg.address}#{Buildings.address_delimiter}l0", "#{entity_bldg.bldg_url}#{Buildings.address_delimiter}l0", 0}
       Map.has_key?(entity, "flr") and Map.has_key?(entity, "flr_url") ->
-        level = extract_flr_level(Map.has_key?(entity, "flr"))
+        level = extract_flr_level(Map.get(entity, "flr"))
         {Map.get(entity, "flr"), Map.get(entity, "flr_url"), level}
       true -> {"g", "g", 0}
     end
@@ -226,7 +226,7 @@ defmodule BldgServer.Buildings do
       Map.has_key?(entity, "bldg_url") ->
         Map.get(entity, "bldg_url")
       Map.has_key?(entity, "flr_url") and Map.has_key?(entity, "name") ->
-        "#{Map.get(entity, "flr_url")}#{Buildings.address_delimiter}#{Map.get(entity, "name")}"
+        "#{Map.get(entity, "flr_url")}#{address_delimiter}#{Map.get(entity, "name")}"
       true ->
         "g"
     end

--- a/bldg_server/lib/bldg_server/buildings.ex
+++ b/bldg_server/lib/bldg_server/buildings.ex
@@ -76,6 +76,7 @@ defmodule BldgServer.Buildings do
 
   """
   def create_bldg(attrs \\ %{}) do
+    # TODO surface any changeset errors
     %Bldg{}
     |> Bldg.changeset(attrs)
     |> Repo.insert()
@@ -201,6 +202,7 @@ defmodule BldgServer.Buildings do
   TODO simplify
   """
   def figure_out_flr(entity) do
+    IO.puts("~~~~~ Figuring out flr")
     {flr, flr_url, flr_level} = cond do
       Map.has_key?(entity, "container_web_url") ->
         %{"container_web_url" => container} = entity
@@ -222,6 +224,7 @@ defmodule BldgServer.Buildings do
   end
 
   def figure_out_bldg_url(entity) do
+    IO.puts("~~~~~ Figuring out bldg_url")
     bldg_url = cond do
       Map.has_key?(entity, "bldg_url") ->
         Map.get(entity, "bldg_url")
@@ -304,6 +307,20 @@ Given an entity:
     # TODO handle the case where the location is already caught
   end
 
+
+  def calculate_nesting_depth(entity) do
+    num_slashes = Map.get(entity, "address")
+    |> String.split(address_delimiter)
+    |> Enum.drop(1) |> length()
+    depth = case num_slashes do
+      0 -> 0
+      1 -> 1
+      _ -> (num_slashes + 1) / 2
+    end
+    Map.put(entity, "nesting_depth", depth)
+  end
+
+
   def remove_build_params(entity) do
     Map.delete(entity, "container_web_url")
   end
@@ -339,6 +356,7 @@ Given an entity:
     |> figure_out_flr()
     |> figure_out_bldg_url()
     |> decide_on_location()
+    |> calculate_nesting_depth()
     |> remove_build_params()
   end
 

--- a/bldg_server/lib/bldg_server/buildings.ex
+++ b/bldg_server/lib/bldg_server/buildings.ex
@@ -54,6 +54,8 @@ defmodule BldgServer.Buildings do
 
   def get_by_web_url(url), do: Repo.get_by(Bldg, web_url: url)
 
+  def get_by_bldg_url(bldg_url), do: Repo.get_by(Bldg, bldg_url: bldg_url)
+
   def get_similar_entities(flr, entity_type) do
     q = from b in Bldg,
         where: b.flr == ^flr and b.entity_type == ^entity_type,

--- a/bldg_server/lib/bldg_server/buildings.ex
+++ b/bldg_server/lib/bldg_server/buildings.ex
@@ -173,6 +173,13 @@ defmodule BldgServer.Buildings do
     get_container(addr)
   end
 
+  def get_container_flr_url(bldg_url) do
+    # returns the container flr url for given bldg url.
+    # TODO verify that a bldg is given & not a flr
+    # TODO if bldg url is g, return g? null?
+    get_container(bldg_url)
+  end
+
   def get_flr_bldg(flr) do
     case flr do
       "g" -> "g"

--- a/bldg_server/lib/bldg_server/buildings.ex
+++ b/bldg_server/lib/bldg_server/buildings.ex
@@ -140,6 +140,15 @@ defmodule BldgServer.Buildings do
     {x, y}
   end
 
+  def extract_flr_level(flr) do
+    l_s = flr
+    |> String.split(address_delimiter)
+    |> List.last()
+    |> String.slice(1..-1)
+    {level, ""} = Integer.parse(l_s)
+    level
+  end
+
   def move_from_speaker({x, y}, offset) do
     {x, y + offset}
   end
@@ -172,19 +181,56 @@ defmodule BldgServer.Buildings do
   # FRAMEWORK
 
 
+  """
+  Determines the flr of a new entity to be created
+  Calculates the following fields:
+  - flr (address)
+  - flr_url (bldg_url of the flr)
+  -  flr_level (flr number)
+  And returns the given entity with these 3 additional fields
+
+  Supports 3 modes:
+  1. Receiving just container bldg address -> flr would be l0 on that bldg
+  2. Receiving just container bldg url -> flr would be l0 on that bldg
+  3. Receiving the flr & flr_url -> no need to figure out, just extract the flr level
+
+  Note that providing just flr or flr_url isn't currently supported.
+
+  TODO simplify
+  """
   def figure_out_flr(entity) do
-    flr = cond do
+    {flr, flr_url, flr_level} = cond do
       Map.has_key?(entity, "container_web_url") ->
         %{"container_web_url" => container} = entity
         entity_bldg = Buildings.get_by_web_url(container)
         # TODO handle the case the container bldg doesn't exist
-        "#{entity_bldg.address}#{Buildings.address_delimiter}l0"
-      Map.has_key?(entity, "flr") ->
-        Map.get(entity, "flr")
-      true -> "g"
+        {"#{entity_bldg.address}#{Buildings.address_delimiter}l0", "#{entity_bldg.bldg_url}#{Buildings.address_delimiter}l0", 0}
+      Map.has_key?(entity, "container_bldg_url") ->
+        %{"container_bldg_url" => container} = entity
+        entity_bldg = Buildings.get_by_bldg_url(container)
+        {"#{entity_bldg.address}#{Buildings.address_delimiter}l0", "#{entity_bldg.bldg_url}#{Buildings.address_delimiter}l0", 0}
+      Map.has_key?(entity, "flr") and Map.has_key?(entity, "flr_url") ->
+        level = extract_flr_level(Map.has_key?(entity, "flr"))
+        {Map.get(entity, "flr"), Map.get(entity, "flr_url"), level}
+      true -> {"g", "g", 0}
     end
     Map.put(entity, "flr", flr)
+    Map.put(entity, "flr_url", flr_url)
+    Map.put(entity, "flr_level", flr_level)
   end
+
+  def figure_out_bldg_url(entity) do
+    bldg_url = cond do
+      Map.has_key?(entity, "bldg_url") ->
+        Map.get(entity, "bldg_url")
+      Map.has_key?(entity, "flr_url") and Map.has_key?(entity, "name") ->
+        "#{Map.get(entity, "flr_url")}#{Buildings.address_delimiter}#{Map.get(entity, "name")}"
+      true ->
+        "g"
+    end
+    Map.put(entity, "bldg_url", bldg_url)
+  end
+
 
 """
 next_location(similar_bldgs)
@@ -289,6 +335,7 @@ Given an entity:
   def build(entity) do
     bldg_params = entity
     |> figure_out_flr()
+    |> figure_out_bldg_url()
     |> decide_on_location()
     |> remove_build_params()
   end

--- a/bldg_server/lib/bldg_server/buildings/bldg.ex
+++ b/bldg_server/lib/bldg_server/buildings/bldg.ex
@@ -18,6 +18,10 @@ defmodule BldgServer.Buildings.Bldg do
     field :x, :integer
     field :y, :integer
     field :owners, {:array, :string}
+    field :bldg_url, :string
+    field :flr_url, :string
+    field :flr_level, :integer
+    field :nesting_depth, :integer
 
     timestamps()
   end
@@ -25,9 +29,9 @@ defmodule BldgServer.Buildings.Bldg do
   @doc false
   def changeset(bldg, attrs) do
     bldg
-    |> cast(attrs, [:address, :flr, :x, :y, :is_composite, :name, :web_url, :entity_type, :state, :category, :tags, :summary, :picture_url, :data, :owners])
-    |> validate_required([:address, :flr, :x, :y, :is_composite, :name, :web_url, :entity_type])
+    |> cast(attrs, [:address, :flr, :x, :y, :is_composite, :name, :web_url, :entity_type, :state, :category, :tags, :summary, :picture_url, :data, :owners, :bldg_url, :flr_url, :flr_level, :nesting_depth])
+    |> validate_required([:bldg_url, :address, :flr, :x, :y, :is_composite, :name, :entity_type, :flr_url, :flr_level, :nesting_depth])
     |> unique_constraint(:address)
-    |> unique_constraint(:web_url)
+    |> unique_constraint(:bldg_url)
   end
 end

--- a/bldg_server/lib/bldg_server/residents.ex
+++ b/bldg_server/lib/bldg_server/residents.ex
@@ -186,22 +186,23 @@ defmodule BldgServer.Residents do
     update_resident(resident, changes)
   end
 
-  def enter_bldg(%Resident{} = resident, address) do
+  def enter_bldg(%Resident{} = resident, address, bldg_url) do
     {initial_x, initial_y} = {8, 40}  # TODO read from config, per bldg type
-    changes = %{flr: "#{address}/l0", location: "#{address}/l0/b(#{initial_x},#{initial_y})", x: initial_x, y: initial_y}
+    changes = %{flr: "#{address}/l0", flr_url: "#{bldg_url}/l0", location: "#{address}/l0/b(#{initial_x},#{initial_y})", x: initial_x, y: initial_y}
     update_resident(resident, changes)
   end
 
-  def exit_bldg(%Resident{} = resident, address) do
+  def exit_bldg(%Resident{} = resident, address, bldg_url) do
     # get the container flr
     container_flr = Buildings.get_container_flr(address)
+    container_flr_url = Buildings.get_container_flr_url(bldg_url)
 
     # determine the location next to the door of the bldg exited
     {x, y} = Buildings.extract_coords(address)
     new_x = x
     new_y = y + 6
 
-    changes = %{flr: container_flr, location: "#{container_flr}/b(#{new_x},#{new_y})", x: new_x, y: new_y}
+    changes = %{flr: container_flr, flr_url: container_flr_url, location: "#{container_flr}/b(#{new_x},#{new_y})", x: new_x, y: new_y}
     update_resident(resident, changes)
   end
 

--- a/bldg_server/lib/bldg_server/residents/resident.ex
+++ b/bldg_server/lib/bldg_server/residents/resident.ex
@@ -17,6 +17,7 @@ defmodule BldgServer.Residents.Resident do
     field :session_id, Ecto.UUID
     field :x, :integer
     field :y, :integer
+    field :flr_url, :string
 
     timestamps()
   end
@@ -24,7 +25,7 @@ defmodule BldgServer.Residents.Resident do
   @doc false
   def changeset(resident, attrs) do
     resident
-    |> cast(attrs, [:email, :alias, :name, :home_bldg, :is_online, :location, :direction, :previous_messages, :other_attributes, :session_id, :last_login_at, :flr, :x, :y])
+    |> cast(attrs, [:email, :alias, :name, :home_bldg, :is_online, :location, :direction, :previous_messages, :other_attributes, :session_id, :last_login_at, :flr, :flr_url, :x, :y])
     |> validate_required([:email, :alias, :name, :home_bldg])
     |> unique_constraint(:email)
   end

--- a/bldg_server/lib/bldg_server_web/bldg_command_executor.ex
+++ b/bldg_server/lib/bldg_server_web/bldg_command_executor.ex
@@ -72,6 +72,7 @@ defmodule BldgServerWeb.BldgCommandExecutor do
           {to_x, to_y} = Buildings.extract_coords(to_addr)
           road = %{
             "flr" => msg["say_flr"],
+            "flr_url" => msg["say_flr_url"],
             "from_address" => from_addr,
             "to_address" => to_addr,
             "from_x" => from_x,
@@ -98,6 +99,7 @@ defmodule BldgServerWeb.BldgCommandExecutor do
           {x, y} = Buildings.extract_coords(msg["say_location"]) |> Buildings.move_from_speaker(-10)
           entity = %{
             "flr" => msg["say_flr"],
+            "flr_url" => msg["say_flr_url"],
             "address" => msg["say_location"],
             "x" => x,
             "y" => y,
@@ -127,6 +129,7 @@ defmodule BldgServerWeb.BldgCommandExecutor do
         {x, y} = Buildings.extract_coords(msg["say_location"]) |> Buildings.move_from_speaker(-10)
         entity = %{
           "flr" => msg["say_flr"],
+          "flr_url" => msg["say_flr_url"],
           "address" => msg["say_location"],
           "x" => x,
           "y" => y,
@@ -156,6 +159,7 @@ defmodule BldgServerWeb.BldgCommandExecutor do
         {x, y} = Buildings.extract_coords(msg["say_location"]) |> Buildings.move_from_speaker(-10)
         entity = %{
           "flr" => msg["say_flr"],
+          "flr_url" => msg["say_flr_url"],
           "address" => msg["say_location"],
           "x" => x,
           "y" => y,
@@ -185,6 +189,7 @@ defmodule BldgServerWeb.BldgCommandExecutor do
         {x, y} = Buildings.extract_coords(msg["say_location"]) |> Buildings.move_from_speaker(-10)
         entity = %{
           "flr" => msg["say_flr"],
+          "flr_url" => msg["say_flr_url"],
           "address" => msg["say_location"],
           "x" => x,
           "y" => y,

--- a/bldg_server/lib/bldg_server_web/bldg_command_executor.ex
+++ b/bldg_server/lib/bldg_server_web/bldg_command_executor.ex
@@ -152,15 +152,20 @@ defmodule BldgServerWeb.BldgCommandExecutor do
 
     # create bldg with entity-type, name & summary
     def execute_command(["/create", entity_type, "bldg", "with", "name", name, "and", "summary" | summary_tokens], msg) do
+
+      IO.puts("~~~~~ executing command create bldg")
+
       # create a bldg with the given entity-type, name & summary, inside the given flr & bldg
 
       # validate that the actor resident/bldg has the sufficient permissions
       container_bldg = Buildings.get_flr_bldg(msg["say_flr"]) |> Buildings.get_bldg!()
       if Enum.find(container_bldg.owners, fn x -> x == msg["resident_email"] end) == nil do
+        IO.puts("~~~~~ Unauthorized")
         raise "#{msg["resident_email"]} is not authorized to create bldgs inside #{container_bldg.web_url}"
       else
         # TODO if creating under a given bldg, send its container_web_url instead of flr
 
+        IO.puts("~~~~~ continue creating bldg")
         {x, y} = Buildings.extract_coords(msg["say_location"]) |> Buildings.move_from_speaker(-10)
         entity = %{
           "flr" => msg["say_flr"],
@@ -174,8 +179,10 @@ defmodule BldgServerWeb.BldgCommandExecutor do
           "state" =>  "approved",
           "owners" => [msg["resident_email"]]
         }
-        Buildings.build(entity)
-        |> Buildings.create_bldg()
+        new_bldg = Buildings.build(entity)
+        IO.puts("~~~~~~~~~~~ Entity to be created:")
+        IO.inspect(new_bldg)
+        Buildings.create_bldg(new_bldg)
       end
     end
 

--- a/bldg_server/lib/bldg_server_web/bldg_command_executor.ex
+++ b/bldg_server/lib/bldg_server_web/bldg_command_executor.ex
@@ -152,20 +152,15 @@ defmodule BldgServerWeb.BldgCommandExecutor do
 
     # create bldg with entity-type, name & summary
     def execute_command(["/create", entity_type, "bldg", "with", "name", name, "and", "summary" | summary_tokens], msg) do
-
-      IO.puts("~~~~~ executing command create bldg")
-
       # create a bldg with the given entity-type, name & summary, inside the given flr & bldg
 
       # validate that the actor resident/bldg has the sufficient permissions
       container_bldg = Buildings.get_flr_bldg(msg["say_flr"]) |> Buildings.get_bldg!()
       if Enum.find(container_bldg.owners, fn x -> x == msg["resident_email"] end) == nil do
-        IO.puts("~~~~~ Unauthorized")
         raise "#{msg["resident_email"]} is not authorized to create bldgs inside #{container_bldg.web_url}"
       else
         # TODO if creating under a given bldg, send its container_web_url instead of flr
 
-        IO.puts("~~~~~ continue creating bldg")
         {x, y} = Buildings.extract_coords(msg["say_location"]) |> Buildings.move_from_speaker(-10)
         entity = %{
           "flr" => msg["say_flr"],
@@ -179,10 +174,8 @@ defmodule BldgServerWeb.BldgCommandExecutor do
           "state" =>  "approved",
           "owners" => [msg["resident_email"]]
         }
-        new_bldg = Buildings.build(entity)
-        IO.puts("~~~~~~~~~~~ Entity to be created:")
-        IO.inspect(new_bldg)
-        Buildings.create_bldg(new_bldg)
+        Buildings.build(entity)
+        |> Buildings.create_bldg()
       end
     end
 

--- a/bldg_server/lib/bldg_server_web/bldg_command_executor.ex
+++ b/bldg_server/lib/bldg_server_web/bldg_command_executor.ex
@@ -24,37 +24,41 @@ defmodule BldgServerWeb.BldgCommandExecutor do
         String.split(msg_text, " ")
     end
 
-    def execute_command(["/add", "owner", email, "to", "bldg", website], msg) do
-      bldg = Buildings.get_by_web_url(website)
+    def execute_command(["/add", "owner", email, "to", "bldg", name], msg) do
+      flr_url = msg["say_flr_url"]
+      bldg_url = "#{flr_url}#{Buildings.address_delimiter}#{name}"
+      bldg = Buildings.get_by_bldg_url(bldg_url)
       # verify that the speaker is also an owner
       if Enum.find(bldg.owners, fn x -> x == msg["resident_email"] end) == nil do
         raise "Unauthorized"
       else
         Buildings.update_bldg(bldg, %{"owners" => [email | bldg.owners]})
-        IO.puts("owner added to bldg #{website}: #{email}")
+        IO.puts("owner added to bldg #{bldg_url}: #{email}")
       end
     end
 
-    def execute_command(["/remove", "owner", email, "from", "bldg", website], msg) do
-      bldg = Buildings.get_by_web_url(website)
+    def execute_command(["/remove", "owner", email, "from", "bldg", name], msg) do
+      flr_url = msg["say_flr_url"]
+      bldg_url = "#{flr_url}#{Buildings.address_delimiter}#{name}"
+      bldg = Buildings.get_by_bldg_url(bldg_url)
       # verify that the speaker is also an owner
       if Enum.find(bldg.owners, fn x -> x == msg["resident_email"] end) == nil do
         raise "Unauthorized"
       else
         pos = Enum.find_index(bldg.owners, fn x -> x == email end)
         if pos == nil do
-          raise "tried to remove non-existing owner #{email} from #{website}"
+          raise "tried to remove non-existing owner #{email} from #{bldg_url}"
         else
           new_owners = List.delete_at(bldg.owners, pos)
           Buildings.update_bldg(bldg, %{"owners" => new_owners})
-          IO.puts("owner removed from bldg #{website}: #{email}")
+          IO.puts("owner removed from bldg #{bldg_url}: #{email}")
         end
       end
     end
 
     # create road between 2 bldgs (using their websites)
     # TODO handle the case where there are multiple bldgs for the same website - check the ones owned by the user in order to resolve
-    def execute_command(["/connect", "between", website1, "and", website2], msg) do
+    def execute_command(["/connect", "between", name1, "and", name2], msg) do
         # create a road between the given bldgs, inside the given flr
 
         # validate that the actor resident/bldg has the sufficient permissions
@@ -63,11 +67,13 @@ defmodule BldgServerWeb.BldgCommandExecutor do
           raise "#{msg["resident_email"]} is not authorized to create roads inside #{container_bldg.web_url}"
         else
           # TODO return proper errors
-
-          bldg1 = Buildings.get_by_web_url(website1)
+          flr_url = msg["say_flr_url"]
+          bldg1_url = "#{flr_url}#{Buildings.address_delimiter}#{name1}"
+          bldg1 = Buildings.get_by_bldg_url(bldg1_url)
           from_addr = bldg1.address
           {from_x, from_y} = Buildings.extract_coords(from_addr)
-          bldg2 = Buildings.get_by_web_url(website2)
+          bldg2_url = "#{flr_url}#{Buildings.address_delimiter}#{name2}"
+          bldg2 = Buildings.get_by_bldg_url(bldg2_url)
           to_addr = bldg2.address
           {to_x, to_y} = Buildings.extract_coords(to_addr)
           road = %{
@@ -85,8 +91,8 @@ defmodule BldgServerWeb.BldgCommandExecutor do
         end
     end
 
-    # create bldg with entity-type, name & website
-    def execute_command(["/create", entity_type, "bldg", "with", "name", name, "and", "website", website], msg) do
+    # create bldg with entity-type, name
+    def execute_command(["/create", entity_type, "bldg", "with", "name", name], msg) do
         # create a bldg with the given entity-type & name, inside the given flr & bldg
 
         # validate that the actor resident/bldg has the sufficient permissions
@@ -103,7 +109,6 @@ defmodule BldgServerWeb.BldgCommandExecutor do
             "address" => msg["say_location"],
             "x" => x,
             "y" => y,
-            "web_url" => website,
             "name" => name,
             "entity_type" => entity_type,
             "state" =>  "approved",
@@ -112,6 +117,36 @@ defmodule BldgServerWeb.BldgCommandExecutor do
           Buildings.build(entity)
           |> Buildings.create_bldg()
         end
+    end
+
+
+    # create bldg with entity-type, name & website
+    def execute_command(["/create", entity_type, "bldg", "with", "name", name, "and", "website", website], msg) do
+      # create a bldg with the given entity-type & name, inside the given flr & bldg
+
+      # validate that the actor resident/bldg has the sufficient permissions
+      container_bldg = Buildings.get_flr_bldg(msg["say_flr"]) |> Buildings.get_bldg!()
+      if Enum.find(container_bldg.owners, fn x -> x == msg["resident_email"] end) == nil do
+        raise "#{msg["resident_email"]} is not authorized to create bldgs inside #{container_bldg.web_url}"
+      else
+        # TODO if creating under a given bldg, send its container_web_url instead of flr
+
+        {x, y} = Buildings.extract_coords(msg["say_location"]) |> Buildings.move_from_speaker(-10)
+        entity = %{
+          "flr" => msg["say_flr"],
+          "flr_url" => msg["say_flr_url"],
+          "address" => msg["say_location"],
+          "x" => x,
+          "y" => y,
+          "web_url" => website,
+          "name" => name,
+          "entity_type" => entity_type,
+          "state" =>  "approved",
+          "owners" => [msg["resident_email"]]
+        }
+        Buildings.build(entity)
+        |> Buildings.create_bldg()
+      end
     end
 
 
@@ -133,7 +168,6 @@ defmodule BldgServerWeb.BldgCommandExecutor do
           "address" => msg["say_location"],
           "x" => x,
           "y" => y,
-          "web_url" => "https://fromteal.app/#{msg["say_location"]}/#{entity_type}/#{name}",
           "name" =>  name,
           "entity_type" =>  entity_type,
           "summary" =>  Enum.join(summary_tokens, " "),
@@ -175,6 +209,36 @@ defmodule BldgServerWeb.BldgCommandExecutor do
       end
     end
 
+
+    # create bldg with entity-type, name & picture
+    def execute_command(["/create", entity_type, "bldg", "with", "name", name, "and", "picture", picture_url], msg) do
+      # create a bldg with the given entity-type, name, website & picture url, inside the given flr & bldg
+
+      # validate that the actor resident/bldg has the sufficient permissions
+      container_bldg = Buildings.get_flr_bldg(msg["say_flr"]) |> Buildings.get_bldg!()
+      if Enum.find(container_bldg.owners, fn x -> x == msg["resident_email"] end) == nil do
+        raise "#{msg["resident_email"]} is not authorized to create bldgs inside #{container_bldg.web_url}"
+      else
+        # TODO if creating under a given bldg, send its container_web_url instead of flr
+
+        {x, y} = Buildings.extract_coords(msg["say_location"]) |> Buildings.move_from_speaker(-10)
+        entity = %{
+          "flr" => msg["say_flr"],
+          "flr_url" => msg["say_flr_url"],
+          "address" => msg["say_location"],
+          "x" => x,
+          "y" => y,
+          "name" => name,
+          "entity_type" => entity_type,
+          "picture_url" => picture_url,
+          "state" =>  "approved",
+          "owners" => [msg["resident_email"]]
+        }
+        Buildings.build(entity)
+        |> Buildings.create_bldg()
+      end
+    end
+
     # create bldg with entity-type, name, website & picture
     def execute_command(["/create", entity_type, "bldg", "with", "name", name, "and", "website", website, "and", "picture", picture_url], msg) do
       # create a bldg with the given entity-type, name, website & picture url, inside the given flr & bldg
@@ -206,12 +270,14 @@ defmodule BldgServerWeb.BldgCommandExecutor do
     end
 
     # move bldg
-    def execute_command(["/move", "bldg", website, "here"], msg) do
+    def execute_command(["/move", "bldg", name, "here"], msg) do
       # update the location of the bldg with the given website to the say location
       # TODO validate that the actor resident/bldg has the sufficient permissions
       # TODO composite bldgs should update the location of their children bldgs as well
       {x, y} = Buildings.extract_coords(msg["say_location"])
-      bldg = Buildings.get_by_web_url(website)
+      flr_url = msg["say_flr_url"]
+      bldg_url = "#{flr_url}#{Buildings.address_delimiter}#{name}"
+      bldg = Buildings.get_by_bldg_url(bldg_url)
       # verify that the speaker is also an owner
       if Enum.find(bldg.owners, fn x -> x == msg["resident_email"] end) == nil do
         raise "Unauthorized"

--- a/bldg_server/lib/bldg_server_web/controllers/resident_controller.ex
+++ b/bldg_server/lib/bldg_server_web/controllers/resident_controller.ex
@@ -157,11 +157,11 @@ defmodule BldgServerWeb.ResidentController do
   end
 
   # ENTER_BLDG action
-  def act(conn, %{"resident_email" => email, "action_type" => "ENTER_BLDG", "bldg_address" => address}) do
+  def act(conn, %{"resident_email" => email, "action_type" => "ENTER_BLDG", "bldg_address" => address, "bldg_url" => bldg_url}) do
     resident = Residents.get_resident_by_email!(email)
     # TODO validate that the resident is authorized to enter the given bldg
 
-    with {:ok, %Resident{} = upd_rsdt} <- Residents.enter_bldg(resident, address) do
+    with {:ok, %Resident{} = upd_rsdt} <- Residents.enter_bldg(resident, address, bldg_url) do
       conn
       |> put_status(:ok)
       |> put_resp_header("location", Routes.resident_path(conn, :show, upd_rsdt))
@@ -170,11 +170,11 @@ defmodule BldgServerWeb.ResidentController do
   end
 
   # EXIT_BLDG action
-  def act(conn, %{"resident_email" => email, "action_type" => "EXIT_BLDG", "bldg_address" => address}) do
+  def act(conn, %{"resident_email" => email, "action_type" => "EXIT_BLDG", "bldg_address" => address, "bldg_url" => bldg_url}) do
     resident = Residents.get_resident_by_email!(email)
     # TODO validate that the resident is authorized to enter the container bldg (although if not, are they essentially locked?)
 
-    with {:ok, %Resident{} = upd_rsdt} <- Residents.exit_bldg(resident, address) do
+    with {:ok, %Resident{} = upd_rsdt} <- Residents.exit_bldg(resident, address, bldg_url) do
       conn
       |> put_status(:ok)
       |> put_resp_header("location", Routes.resident_path(conn, :show, upd_rsdt))

--- a/bldg_server/lib/bldg_server_web/views/bldg_view.ex
+++ b/bldg_server/lib/bldg_server_web/views/bldg_view.ex
@@ -16,12 +16,16 @@ defmodule BldgServerWeb.BldgView do
 
   def render("bldg.json", %{bldg: bldg}) do
     %{id: bldg.id,
+      bldg_url: bldg.bldg_url,
       address: bldg.address,
+      name: bldg.name,
       flr: bldg.flr,
+      flr_url: bldg.flr_url,
+      flr_level: bldg.flr_level,
+      nesting_depth: bldg.nesting_depth,
       x: bldg.x,
       y: bldg.y,
       is_composite: bldg.is_composite,
-      name: bldg.name,
       web_url: bldg.web_url,
       entity_type: bldg.entity_type,
       state: bldg.state,

--- a/bldg_server/lib/bldg_server_web/views/resident_view.ex
+++ b/bldg_server/lib/bldg_server_web/views/resident_view.ex
@@ -23,6 +23,7 @@ defmodule BldgServerWeb.ResidentView do
       is_online: resident.is_online,
       location: resident.location,
       flr: resident.flr,
+      flr_url: resident.flr_url,
       x: resident.x,
       y: resident.y,
       direction: resident.direction,

--- a/bldg_server/priv/repo/migrations/20220913185804_add_bldg_url_field.exs
+++ b/bldg_server/priv/repo/migrations/20220913185804_add_bldg_url_field.exs
@@ -1,0 +1,9 @@
+defmodule BldgServer.Repo.Migrations.AddBldgUrlField do
+  use Ecto.Migration
+
+  def change do
+    alter table("bldgs") do
+      add :bldg_url, :string
+    end
+  end
+end

--- a/bldg_server/priv/repo/migrations/20220913202629_add_bldg_flr_field.exs
+++ b/bldg_server/priv/repo/migrations/20220913202629_add_bldg_flr_field.exs
@@ -1,0 +1,9 @@
+defmodule BldgServer.Repo.Migrations.AddBldgFlrField do
+  use Ecto.Migration
+
+  def change do
+    alter table("bldgs") do
+      add :flr_url, :string
+    end
+  end
+end

--- a/bldg_server/priv/repo/migrations/20220913203337_add_bldg_derived_fields.exs
+++ b/bldg_server/priv/repo/migrations/20220913203337_add_bldg_derived_fields.exs
@@ -1,0 +1,14 @@
+defmodule BldgServer.Repo.Migrations.AddBldgDerivedFields do
+  use Ecto.Migration
+
+  def change do
+    alter table("bldgs") do
+      add :flr_level, :integer
+    end
+
+    alter table("bldgs") do
+      add :nesting_depth, :integer
+    end
+  end
+
+end

--- a/bldg_server/priv/repo/migrations/20220914022721_add_flr_url_to_resident.exs
+++ b/bldg_server/priv/repo/migrations/20220914022721_add_flr_url_to_resident.exs
@@ -1,0 +1,11 @@
+defmodule BldgServer.Repo.Migrations.AddFlrUrlToResident do
+  use Ecto.Migration
+
+  def change do
+
+    alter table("residents") do
+      add :flr_url, :string
+    end
+
+  end
+end


### PR DESCRIPTION
## Why
It is not so usable to use external web URL as bldg unique identifier, because users can't easily remember URL's or discern between them. Instead use unique name (within flr) for referring to bldgs & have a new unique global identifier - bldg URL - based on the hierarchy of names.

## What
Switch to using an intelligible bldg URL instead of the external Web URL or internal address.

Format can be: 
`bldg://g/<name>/l0/<name>/l2/<name>`

E.g., for a bldg with:
        `"address": "g/b(16,92)/l0/b(34,16)"`
We'll have:
        `"bldg_url": "g/fromTeal/l0/test7"`

Implication is that bldg names within floors must be unique. This means that islands, towns, streets, lots should be container bldgs, because otherwise there will be too many bldgs by different sources & no way to ensure uniqueness.

When creating bldgs, you only need to specify the name, & the form should enforce uniqueness within the flr

When choosing entity in a drop-down, only show the names of the entities on the flr, & potentially prefix with entity-type
