### PR TITLE
Promote bldgs

### DIFF
--- a/bldg_server/lib/bldg_server_web/bldg_command_executor.ex
+++ b/bldg_server/lib/bldg_server_web/bldg_command_executor.ex
@@ -26,12 +26,13 @@ defmodule BldgServerWeb.BldgCommandExecutor do
     end
 
     def determine_wallpaper_based_on_location(x, _y) do
+      # TODO generalize a bit
       cond do
         x > 80 -> 1
-        x <= 80 and x > 46 -> 2
-        x <= 46 and x > 6 -> 3
-        x <= 6 and x > -32 -> 4
-        x <= -32 -> 5
+        x <= 80 and x > 66 -> 2
+        x <= 66 and x > 18 -> 3
+        x <= 18 and x > -28 -> 4
+        x <= -28 -> 5
       end
     end
 

--- a/bldg_server/lib/bldg_server_web/bldg_command_executor.ex
+++ b/bldg_server/lib/bldg_server_web/bldg_command_executor.ex
@@ -102,7 +102,7 @@ defmodule BldgServerWeb.BldgCommandExecutor do
         end
     end
 
-    # create bldg with entity-type, name
+    # create bldg with: name
     def execute_command(["/create", entity_type, "bldg", "with", "name", name], msg) do
         # create a bldg with the given entity-type & name, inside the given flr & bldg
 
@@ -131,7 +131,7 @@ defmodule BldgServerWeb.BldgCommandExecutor do
     end
 
 
-    # create bldg with entity-type, name & website
+    # create bldg with: name & website
     def execute_command(["/create", entity_type, "bldg", "with", "name", name, "and", "website", website], msg) do
       # create a bldg with the given entity-type & name, inside the given flr & bldg
 
@@ -161,7 +161,7 @@ defmodule BldgServerWeb.BldgCommandExecutor do
     end
 
 
-    # create bldg with entity-type, name & summary
+    # create bldg with: name & summary
     def execute_command(["/create", entity_type, "bldg", "with", "name", name, "and", "summary" | summary_tokens], msg) do
       # create a bldg with the given entity-type, name & summary, inside the given flr & bldg
 
@@ -190,7 +190,7 @@ defmodule BldgServerWeb.BldgCommandExecutor do
       end
     end
 
-    # create bldg with entity-type, name, website & summary
+    # create bldg with: name, website & summary
     def execute_command(["/create", entity_type, "bldg", "with", "name", name, "and", "website", website, "and", "summary" | summary_tokens], msg) do
       # create a bldg with the given entity-type, name, website & summary, inside the given flr & bldg
 
@@ -221,7 +221,37 @@ defmodule BldgServerWeb.BldgCommandExecutor do
     end
 
 
-    # create bldg with entity-type, name & picture
+    # create bldg with: name, picture & summary
+    def execute_command(["/create", entity_type, "bldg", "with", "name", name, "and", "picture", picture_url, "and", "summary" | summary_tokens], msg) do
+      # create a bldg with the given entity-type, name, website & picture url, inside the given flr & bldg
+
+      # validate that the actor resident/bldg has the sufficient permissions
+      container_bldg = Buildings.get_flr_bldg(msg["say_flr"]) |> Buildings.get_bldg!()
+      if Enum.find(container_bldg.owners, fn x -> x == msg["resident_email"] end) == nil do
+        raise "#{msg["resident_email"]} is not authorized to create bldgs inside #{container_bldg.web_url}"
+      else
+        # TODO if creating under a given bldg, send its container_web_url instead of flr
+
+        {x, y} = Buildings.extract_coords(msg["say_location"]) |> Buildings.move_from_speaker(-10)
+        entity = %{
+          "flr" => msg["say_flr"],
+          "flr_url" => msg["say_flr_url"],
+          "address" => msg["say_location"],
+          "x" => x,
+          "y" => y,
+          "name" => name,
+          "entity_type" => entity_type,
+          "picture_url" => picture_url,
+          "summary" =>  Enum.join(summary_tokens, " "),
+          "state" =>  "approved",
+          "owners" => [msg["resident_email"]]
+        }
+        Buildings.build(entity)
+        |> Buildings.create_bldg()
+      end
+    end
+
+    # create bldg with: name, picture
     def execute_command(["/create", entity_type, "bldg", "with", "name", name, "and", "picture", picture_url], msg) do
       # create a bldg with the given entity-type, name, website & picture url, inside the given flr & bldg
 
@@ -250,7 +280,7 @@ defmodule BldgServerWeb.BldgCommandExecutor do
       end
     end
 
-    # create bldg with entity-type, name, website & picture
+    # create bldg with: name, website & picture
     def execute_command(["/create", entity_type, "bldg", "with", "name", name, "and", "website", website, "and", "picture", picture_url], msg) do
       # create a bldg with the given entity-type, name, website & picture url, inside the given flr & bldg
 
@@ -272,6 +302,37 @@ defmodule BldgServerWeb.BldgCommandExecutor do
           "name" => name,
           "entity_type" => entity_type,
           "picture_url" => picture_url,
+          "state" =>  "approved",
+          "owners" => [msg["resident_email"]]
+        }
+        Buildings.build(entity)
+        |> Buildings.create_bldg()
+      end
+    end
+
+    # create bldg with: name, website, picture & summary
+    def execute_command(["/create", entity_type, "bldg", "with", "name", name, "and", "website", website, "and", "picture", picture_url, "and", "summary" | summary_tokens], msg) do
+      # create a bldg with the given entity-type, name, website & picture url, inside the given flr & bldg
+
+      # validate that the actor resident/bldg has the sufficient permissions
+      container_bldg = Buildings.get_flr_bldg(msg["say_flr"]) |> Buildings.get_bldg!()
+      if Enum.find(container_bldg.owners, fn x -> x == msg["resident_email"] end) == nil do
+        raise "#{msg["resident_email"]} is not authorized to create bldgs inside #{container_bldg.web_url}"
+      else
+        # TODO if creating under a given bldg, send its container_web_url instead of flr
+
+        {x, y} = Buildings.extract_coords(msg["say_location"]) |> Buildings.move_from_speaker(-10)
+        entity = %{
+          "flr" => msg["say_flr"],
+          "flr_url" => msg["say_flr_url"],
+          "address" => msg["say_location"],
+          "x" => x,
+          "y" => y,
+          "web_url" => website,
+          "name" => name,
+          "entity_type" => entity_type,
+          "picture_url" => picture_url,
+          "summary" =>  Enum.join(summary_tokens, " "),
           "state" =>  "approved",
           "owners" => [msg["resident_email"]]
         }

--- a/bldg_server/lib/bldg_server_web/bldg_command_executor.ex
+++ b/bldg_server/lib/bldg_server_web/bldg_command_executor.ex
@@ -361,7 +361,6 @@ defmodule BldgServerWeb.BldgCommandExecutor do
 
     # promote bldg inside
     def execute_command(["/promote", "bldg", name, "inside"], msg) do
-      IO.puts("~~~~~ Handling bldg promotion inside")
       # get speaker location (we'll need it to determine which wallpaper to set)
       {x, y} = Buildings.extract_coords(msg["say_location"])
       # get the promoted bldg
@@ -387,12 +386,10 @@ defmodule BldgServerWeb.BldgCommandExecutor do
 
     # demote bldg inside
     def execute_command(["/demote", "bldg", name, "inside"], msg) do
-      IO.puts("~~~~~ Handling bldg demotion inside")
       # get the promoted bldg
       flr_url = msg["say_flr_url"]
       bldg_url = "#{flr_url}#{Buildings.address_delimiter}#{name}"
       bldg = Buildings.get_by_bldg_url(bldg_url)
-      IO.puts("~~~~~~ promoted bldg has picture-url? #{bldg.picture_url}")
       picture_url = bldg.picture_url
       cond do
         picture_url == nil ->
@@ -404,9 +401,8 @@ defmodule BldgServerWeb.BldgCommandExecutor do
             {_, data} = Jason.decode(container.data || "{}")
             # find the key matching the picture-url
             data_key = data
-            |> Enum.find(fn {key, val} -> val == picture_url end)
+            |> Enum.find(fn {_, val} -> val == picture_url end)
             |> elem(0)
-            IO.puts("~~~~~~~~~~~ Found promoted entity key to delete: #{data_key}")
             # TODO check that key exists
             {_, new_data} = Map.delete(data, data_key) |> Jason.encode()
             # update bldg

--- a/bldg_server/lib/bldg_server_web/bldg_command_executor.ex
+++ b/bldg_server/lib/bldg_server_web/bldg_command_executor.ex
@@ -25,6 +25,16 @@ defmodule BldgServerWeb.BldgCommandExecutor do
         String.split(msg_text, " ")
     end
 
+    def determine_wallpaper_based_on_location(x, _y) do
+      cond do
+        x > 80 -> 1
+        x <= 80 and x > 46 -> 2
+        x <= 46 and x > 6 -> 3
+        x <= 6 and x > -32 -> 4
+        x <= -32 -> 5
+      end
+    end
+
     def execute_command(["/add", "owner", email, "to", "bldg", name], msg) do
       flr_url = msg["say_flr_url"]
       bldg_url = "#{flr_url}#{Buildings.address_delimiter}#{name}"
@@ -299,12 +309,12 @@ defmodule BldgServerWeb.BldgCommandExecutor do
       bldg = Buildings.get_by_bldg_url(bldg_url)
       IO.puts("~~~~~~ promoted bldg has picture-url? #{bldg.picture_url}")
       # determine nearest wallpaper
-      wallpaper_num = 2   # TODO implement
+      wallpaper_num = determine_wallpaper_based_on_location(x, y)
       # get the container bldg
       container_bldg_url = Buildings.get_container(flr_url)
       container = Buildings.get_by_bldg_url(container_bldg_url)
       # TODO check whether promoted bldg indeed has picture_url
-      {_, data} = Jason.decode(container.data)
+      {_, data} = Jason.decode(container.data || "{}")
       {_, new_data} = Map.merge(data, %{"promoted-inside-#{wallpaper_num}-picture-url" => bldg.picture_url}) |> Jason.encode()
       # update bldg
       Buildings.update_bldg(container, %{"data" => new_data})

--- a/bldg_server/priv/repo/migrations/20220918150500_change_data_to_text.exs
+++ b/bldg_server/priv/repo/migrations/20220918150500_change_data_to_text.exs
@@ -1,0 +1,9 @@
+defmodule BldgServer.Repo.Migrations.ChangeDataToText do
+  use Ecto.Migration
+
+  def change do
+    alter table(:bldgs) do
+      modify :data, :text
+    end
+  end
+end


### PR DESCRIPTION
## Why
Enable users to promote a bldg to show up on a wall on the container bldg

## What
- New chat commands (`promote` & `demote`) that receive an object name & add its picture as a data attribute on its container bldg:
- `/promote bldg <name> inside`, `/demote bldg <name> inside`
- In this 1st pass of the feature, we support 5 locations on the container bldg, & based on the location in which the chat command was spoken, we'll choose one of the 5 locations
- Demote undoes the promote operation (unless an entity was promoted to multiple locations, in which case demote will just undo 1 of them)


## Left to do
- Support promoting also  the text of the entity, & not just the picture
- Support promoting also outside the container bldg (the modifier `inside` will be changed to `outside`)
- Support floors - promotion on different floors, based on the speaker location
- Support different container bldgs
- There's some issue with the demote, where the response doesn't arrive to the client, so it doesn't refresh the view