### PR TITLE
Basic battery support

### DIFF
--- a/bldg_server/lib/bldg_server/application.ex
+++ b/bldg_server/lib/bldg_server/application.ex
@@ -15,6 +15,7 @@ defmodule BldgServer.Application do
       # Starts a worker by calling: BldgServer.Worker.start_link(arg)
       # {BldgServer.Worker, arg},
       BldgServerWeb.BldgCommandExecutor,
+      BldgServerWeb.BatteryChatDispatcher,
       # Start the http client
       {Finch, name: FinchClient}
     ]

--- a/bldg_server/lib/bldg_server/batteries.ex
+++ b/bldg_server/lib/bldg_server/batteries.ex
@@ -1,0 +1,146 @@
+defmodule BldgServer.Batteries do
+  @moduledoc """
+  The Batteries context.
+  """
+
+  import Ecto.Query, warn: false
+  alias BldgServer.Repo
+
+  alias BldgServer.Batteries.Battery
+
+  @doc """
+  Returns the list of batteries.
+
+  ## Examples
+
+      iex> list_batteries()
+      [%Battery{}, ...]
+
+  """
+  def list_batteries do
+    Repo.all(Battery)
+  end
+
+
+  @doc """
+  Returns the list of attached batteries in a given floor.
+
+  ## Examples
+
+      iex> get_batteries_in_floor(flr)
+      [%Battery{}, ...]
+
+  """
+  def get_batteries_in_floor(flr) do
+    q = from b in Battery, where: b.flr == ^flr and b.is_attached
+    Repo.all(q)
+  end
+
+
+
+
+
+  @doc """
+  Gets a single battery.
+
+  Raises `Ecto.NoResultsError` if the Battery does not exist.
+
+  ## Examples
+
+      iex> get_battery!(123)
+      %Battery{}
+
+      iex> get_battery!(456)
+      ** (Ecto.NoResultsError)
+
+  """
+  def get_battery!(id), do: Repo.get!(Battery, id)
+
+
+
+  @doc """
+  Gets a single battery by it's container bldg's address.
+
+  Raises `Ecto.NoResultsError` if the Battery does not exist.
+
+  ## Examples
+
+      iex> get_battery_by_bldg_address!("g-b(10,20)")
+      %Battery{}
+
+      iex> get_battery_by_bldg_address!("g-b(30,40)")
+      ** (Ecto.NoResultsError)
+
+  """
+  def get_attached_battery_by_bldg_address!(bldg_address) do
+    clauses = [is_attached: :true, bldg_address: bldg_address]
+    Repo.get_by!(Battery, clauses)
+  end
+
+
+
+  @doc """
+  Creates a battery.
+
+  ## Examples
+
+      iex> create_battery(%{field: value})
+      {:ok, %Battery{}}
+
+      iex> create_battery(%{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def create_battery(attrs \\ %{}) do
+    %Battery{}
+    |> Battery.changeset(attrs)
+    |> Repo.insert()
+  end
+
+  @doc """
+  Updates a battery.
+
+  ## Examples
+
+      iex> update_battery(battery, %{field: new_value})
+      {:ok, %Battery{}}
+
+      iex> update_battery(battery, %{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def update_battery(%Battery{} = battery, attrs) do
+    battery
+    |> Battery.changeset(attrs)
+    |> Repo.update()
+  end
+
+  @doc """
+  Deletes a battery.
+
+  ## Examples
+
+      iex> delete_battery(battery)
+      {:ok, %Battery{}}
+
+      iex> delete_battery(battery)
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def delete_battery(%Battery{} = battery) do
+    Repo.delete(battery)
+  end
+
+  @doc """
+  Returns an `%Ecto.Changeset{}` for tracking battery changes.
+
+  ## Examples
+
+      iex> change_battery(battery)
+      %Ecto.Changeset{source: %Battery{}}
+
+  """
+  def change_battery(%Battery{} = battery) do
+    Battery.changeset(battery, %{})
+  end
+end

--- a/bldg_server/lib/bldg_server/batteries.ex
+++ b/bldg_server/lib/bldg_server/batteries.ex
@@ -59,6 +59,25 @@ defmodule BldgServer.Batteries do
 
 
   @doc """
+  Gets a single battery by it's container bldg's url.
+
+  Raises `Ecto.NoResultsError` if the Battery does not exist.
+
+  ## Examples
+
+      iex> get_battery_by_bldg_url!("g/bldg_name")
+      %Battery{}
+
+      iex> get_battery_by_bldg_url!("g/bldg_name")
+      ** (Ecto.NoResultsError)
+
+  """
+  def get_attached_battery_by_bldg_url!(bldg_url) do
+    clauses = [is_attached: :true, bldg_url: bldg_url]
+    Repo.get_by!(Battery, clauses)
+  end
+
+  @doc """
   Gets a single battery by it's container bldg's address.
 
   Raises `Ecto.NoResultsError` if the Battery does not exist.
@@ -76,7 +95,6 @@ defmodule BldgServer.Batteries do
     clauses = [is_attached: :true, bldg_address: bldg_address]
     Repo.get_by!(Battery, clauses)
   end
-
 
 
   @doc """

--- a/bldg_server/lib/bldg_server/batteries/battery.ex
+++ b/bldg_server/lib/bldg_server/batteries/battery.ex
@@ -1,0 +1,25 @@
+defmodule BldgServer.Batteries.Battery do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  schema "batteries" do
+    field :battery_type, :string
+    field :battery_vendor, :string
+    field :battery_version, :string
+    field :bldg_address, :string
+    field :callback_url, :string
+    field :direct_only, :boolean, default: false
+    field :flr, :string
+    field :is_attached, :boolean, default: false
+
+    timestamps()
+  end
+
+  @doc false
+  def changeset(battery, attrs) do
+    battery
+    |> cast(attrs, [:bldg_address, :flr, :callback_url, :is_attached, :direct_only, :battery_type, :battery_version, :battery_vendor])
+    |> validate_required([:bldg_address, :flr, :callback_url])
+    |> unique_constraint(:single_attached_battery_in_bldg, name: :single_attached_battery_in_bldg)
+  end
+end

--- a/bldg_server/lib/bldg_server/batteries/battery.ex
+++ b/bldg_server/lib/bldg_server/batteries/battery.ex
@@ -6,7 +6,7 @@ defmodule BldgServer.Batteries.Battery do
     field :battery_type, :string
     field :battery_vendor, :string
     field :battery_version, :string
-    field :bldg_address, :string
+    field :bldg_url, :string
     field :callback_url, :string
     field :direct_only, :boolean, default: false
     field :flr, :string
@@ -18,8 +18,8 @@ defmodule BldgServer.Batteries.Battery do
   @doc false
   def changeset(battery, attrs) do
     battery
-    |> cast(attrs, [:bldg_address, :flr, :callback_url, :is_attached, :direct_only, :battery_type, :battery_version, :battery_vendor])
-    |> validate_required([:bldg_address, :flr, :callback_url])
+    |> cast(attrs, [:bldg_url, :flr, :callback_url, :is_attached, :direct_only, :battery_type, :battery_version, :battery_vendor])
+    |> validate_required([:bldg_url, :flr, :callback_url])
     |> unique_constraint(:single_attached_battery_in_bldg, name: :single_attached_battery_in_bldg)
   end
 end

--- a/bldg_server/lib/bldg_server/buildings.ex
+++ b/bldg_server/lib/bldg_server/buildings.ex
@@ -360,12 +360,47 @@ Given an entity:
     }
   """
   def build(entity) do
-    bldg_params = entity
+    entity
     |> figure_out_flr()
     |> figure_out_bldg_url()
     |> decide_on_location()
     |> calculate_nesting_depth()
     |> remove_build_params()
+  end
+
+
+  # TODO duplicate code, please consolidate
+  def append_message_to_list(msg_list, msg) do
+    case msg_list do
+      nil -> [msg]
+      _ -> [msg | msg_list]
+    end
+  end
+
+
+  # TODO duplicate code, please consolidate
+  def is_command(msg_text), do: String.at(msg_text, 0) == "/"
+
+
+  # TODO duplicate code, please consolidate
+  def say(%Bldg{} = bldg, msg) do
+    {_, text} = JSON.encode(msg)
+
+    new_prev_messages = append_message_to_list(bldg.previous_messages, text)
+    changes = %{previous_messages: new_prev_messages}
+    result = update_bldg(bldg, changes)
+
+    # the message may be a command for bldg manipulation, so
+    # broadcast an event for it, so that the command executor can process it
+    if is_command(msg["say_text"]) do
+      BldgServerWeb.Endpoint.broadcast!(
+        "chat",
+        "new_message",
+        msg
+      )
+    end
+
+    result
   end
 
 end

--- a/bldg_server/lib/bldg_server/buildings.ex
+++ b/bldg_server/lib/bldg_server/buildings.ex
@@ -384,7 +384,9 @@ Given an entity:
 
   # TODO duplicate code, please consolidate
   def say(%Bldg{} = bldg, msg) do
-    {_, text} = JSON.encode(msg)
+    {_, text} = msg
+    |> Map.merge(%{"say_time" => System.system_time(:millisecond)})
+    |> JSON.encode()
 
     new_prev_messages = append_message_to_list(bldg.previous_messages, text)
     changes = %{previous_messages: new_prev_messages}

--- a/bldg_server/lib/bldg_server/buildings/bldg.ex
+++ b/bldg_server/lib/bldg_server/buildings/bldg.ex
@@ -22,6 +22,7 @@ defmodule BldgServer.Buildings.Bldg do
     field :flr_url, :string
     field :flr_level, :integer
     field :nesting_depth, :integer
+    field :previous_messages, {:array, :string}
 
     timestamps()
   end
@@ -29,7 +30,7 @@ defmodule BldgServer.Buildings.Bldg do
   @doc false
   def changeset(bldg, attrs) do
     bldg
-    |> cast(attrs, [:address, :flr, :x, :y, :is_composite, :name, :web_url, :entity_type, :state, :category, :tags, :summary, :picture_url, :data, :owners, :bldg_url, :flr_url, :flr_level, :nesting_depth])
+    |> cast(attrs, [:address, :flr, :x, :y, :is_composite, :name, :web_url, :entity_type, :state, :category, :tags, :summary, :picture_url, :data, :owners, :bldg_url, :flr_url, :flr_level, :nesting_depth, :previous_messages])
     |> validate_required([:bldg_url, :address, :flr, :x, :y, :is_composite, :name, :entity_type, :flr_url, :flr_level, :nesting_depth])
     |> unique_constraint(:address)
     |> unique_constraint(:bldg_url)

--- a/bldg_server/lib/bldg_server/residents.ex
+++ b/bldg_server/lib/bldg_server/residents.ex
@@ -223,7 +223,9 @@ defmodule BldgServer.Residents do
 
 
   def say(%Resident{} = resident, msg) do
-    {_, text} = JSON.encode(msg)
+    {_, text} = msg
+    |> Map.merge(%{"say_time" => System.system_time(:millisecond)})
+    |> JSON.encode()
 
     new_prev_messages = append_message_to_list(resident.previous_messages, text)
     changes = %{previous_messages: new_prev_messages}

--- a/bldg_server/lib/bldg_server_web/battery_chat_dispatcher.ex
+++ b/bldg_server/lib/bldg_server_web/battery_chat_dispatcher.ex
@@ -1,0 +1,49 @@
+defmodule BldgServerWeb.BatteryChatDispatcher do
+  use GenServer
+  require Logger
+  alias BldgServer.PubSub
+
+  alias BldgServer.Batteries
+
+
+  def start_link(_) do
+    GenServer.start_link(__MODULE__, name: __MODULE__)
+  end
+
+  def init(_) do
+    Phoenix.PubSub.subscribe(PubSub, "chat")
+    IO.puts("subscribed")
+    {:ok, %{}}
+  end
+
+  def handle_call(:get, _, state) do
+    {:reply, state, state}
+  end
+
+
+  def send_message_to_battery(callback_url, msg) do
+    Logger.info("About to invoke battery callback URL at: #{callback_url}")
+    header_key = "content-type"
+    header_val = "application/json"
+    {_, msg_json} = Jason.encode(msg)
+    Finch.build(:post, callback_url, [{header_key, header_val}], msg_json)
+    |> Finch.request(FinchClient)
+    |> IO.inspect()
+  end
+
+
+  #def handle_info({sender, message, flr}, state) do
+  def handle_info(%{event: "new_message", payload: new_message}, state) do
+    #Logger.info("chat message received at #{flr} from #{sender}: #{message}")
+    Logger.info("chat message received: #{new_message["message"]}")
+
+    # query for all batteries inside that message flr
+    # & invoke the callback url per each battery, with the message details in the body
+
+    batteries = ["flr"]
+    |> Batteries.get_batteries_in_floor()
+    |> Enum.map(fn b -> send_message_to_battery(b.callback_url, new_message) end)
+
+    {:noreply, state}
+  end
+end

--- a/bldg_server/lib/bldg_server_web/bldg_command_executor.ex
+++ b/bldg_server/lib/bldg_server_web/bldg_command_executor.ex
@@ -13,7 +13,7 @@ defmodule BldgServerWeb.BldgCommandExecutor do
 
     def init(_) do
       Phoenix.PubSub.subscribe(PubSub, "chat")
-      IO.puts("subscribed")
+      IO.puts("~~~~~~~~~~~~ [bldg command executor] subscribed to chat")
       {:ok, %{}}
     end
 
@@ -415,7 +415,7 @@ defmodule BldgServerWeb.BldgCommandExecutor do
     #def handle_info({sender, message, flr}, state) do
     def handle_info(%{event: "new_message", payload: new_message}, state) do
       #Logger.info("chat message received at #{flr} from #{sender}: #{message}")
-      Logger.info("chat message received: #{new_message["message"]}")
+      Logger.info("~~~~~~~~~~~~ [bldg command executor] chat message received: #{new_message["message"]}")
 
       new_message["say_text"]
       |> parse_command()

--- a/bldg_server/lib/bldg_server_web/controllers/battery_controller.ex
+++ b/bldg_server/lib/bldg_server_web/controllers/battery_controller.ex
@@ -1,0 +1,64 @@
+defmodule BldgServerWeb.BatteryController do
+  use BldgServerWeb, :controller
+
+  alias BldgServer.Batteries
+  alias BldgServer.Batteries.Battery
+
+  action_fallback BldgServerWeb.FallbackController
+
+  def index(conn, _params) do
+    batteries = Batteries.list_batteries()
+    render(conn, "index.json", batteries: batteries)
+  end
+
+  def attach(conn, %{"battery" => battery_params}) do
+    # add is_attached to the params
+    IO.inspect(battery_params)
+    battery_attrs = Map.merge(battery_params, %{"is_attached" => :true})
+    with {:ok, %Battery{} = battery} <- Batteries.create_battery(battery_attrs) do
+      conn
+      |> put_status(:created)
+      |> put_resp_header("location", Routes.battery_path(conn, :show, battery))
+      |> render("show.json", battery: battery)
+    end
+  end
+
+  def detach(conn, %{"bldg_address" => bldg_address}) do
+    IO.puts("Detaching battery from bldg at #{bldg_address}")
+    battery = Batteries.get_attached_battery_by_bldg_address!(bldg_address)
+
+    with {:ok, %Battery{}} <- Batteries.delete_battery(battery) do
+      send_resp(conn, :no_content, "")
+    end
+  end
+
+  def create(conn, %{"battery" => battery_params}) do
+    with {:ok, %Battery{} = battery} <- Batteries.create_battery(battery_params) do
+      conn
+      |> put_status(:created)
+      |> put_resp_header("location", Routes.battery_path(conn, :show, battery))
+      |> render("show.json", battery: battery)
+    end
+  end
+
+  def show(conn, %{"id" => id}) do
+    battery = Batteries.get_battery!(id)
+    render(conn, "show.json", battery: battery)
+  end
+
+  def update(conn, %{"id" => id, "battery" => battery_params}) do
+    battery = Batteries.get_battery!(id)
+
+    with {:ok, %Battery{} = battery} <- Batteries.update_battery(battery, battery_params) do
+      render(conn, "show.json", battery: battery)
+    end
+  end
+
+  def delete(conn, %{"id" => id}) do
+    battery = Batteries.get_battery!(id)
+
+    with {:ok, %Battery{}} <- Batteries.delete_battery(battery) do
+      send_resp(conn, :no_content, "")
+    end
+  end
+end

--- a/bldg_server/lib/bldg_server_web/controllers/battery_controller.ex
+++ b/bldg_server/lib/bldg_server_web/controllers/battery_controller.ex
@@ -23,9 +23,9 @@ defmodule BldgServerWeb.BatteryController do
     end
   end
 
-  def detach(conn, %{"bldg_address" => bldg_address}) do
-    IO.puts("Detaching battery from bldg at #{bldg_address}")
-    battery = Batteries.get_attached_battery_by_bldg_address!(bldg_address)
+  def detach(conn, %{"bldg_url" => bldg_url}) do
+    IO.puts("Detaching battery from bldg #{bldg_url}")
+    battery = Batteries.get_attached_battery_by_bldg_url!(bldg_url)
 
     with {:ok, %Battery{}} <- Batteries.delete_battery(battery) do
       send_resp(conn, :no_content, "")

--- a/bldg_server/lib/bldg_server_web/controllers/battery_controller.ex
+++ b/bldg_server/lib/bldg_server_web/controllers/battery_controller.ex
@@ -61,4 +61,5 @@ defmodule BldgServerWeb.BatteryController do
       send_resp(conn, :no_content, "")
     end
   end
+
 end

--- a/bldg_server/lib/bldg_server_web/controllers/bldg_controller.ex
+++ b/bldg_server/lib/bldg_server_web/controllers/bldg_controller.ex
@@ -79,7 +79,7 @@ defmodule BldgServerWeb.BldgController do
 
 
   # SAY action
-  def act(conn, %{"resident_email" => email, "bldg_url" => bldg_url, "action_type" => "SAY", "say_speaker" => _speaker, "say_text" => _text, "say_time" => _msg_time, "say_flr" => _flr, "say_location" => _location, "say_mimetype" => _msg_mimetype, "say_recipient" => _recipient} = msg) do
+  def act(conn, %{"resident_email" => email, "bldg_url" => bldg_url, "action_type" => "SAY", "say_speaker" => _speaker, "say_text" => _text, "say_flr" => _flr, "say_location" => _location, "say_mimetype" => _msg_mimetype, "say_recipient" => _recipient} = msg) do
     bldg = Buildings.get_by_bldg_url(bldg_url)
     # TODO verify that the battery has a valid session & access & chat permissions in this bldg
 

--- a/bldg_server/lib/bldg_server_web/controllers/bldg_controller.ex
+++ b/bldg_server/lib/bldg_server_web/controllers/bldg_controller.ex
@@ -77,4 +77,17 @@ defmodule BldgServerWeb.BldgController do
     end
   end
 
+
+  # SAY action
+  def act(conn, %{"resident_email" => email, "bldg_url" => bldg_url, "action_type" => "SAY", "say_speaker" => _speaker, "say_text" => _text, "say_time" => _msg_time, "say_flr" => _flr, "say_location" => _location, "say_mimetype" => _msg_mimetype, "say_recipient" => _recipient} = msg) do
+    bldg = Buildings.get_by_bldg_url(bldg_url)
+    # TODO verify that the battery has a valid session & access & chat permissions in this bldg
+
+    with {:ok, %Bldg{} = upd_bldg} <- Buildings.say(bldg, msg) do
+      conn
+      |> put_status(:ok)
+      |> put_resp_header("location", Routes.bldg_path(conn, :show, upd_bldg))
+      |> render("show.json", bldg: upd_bldg)
+    end
+  end
 end

--- a/bldg_server/lib/bldg_server_web/controllers/resident_controller.ex
+++ b/bldg_server/lib/bldg_server_web/controllers/resident_controller.ex
@@ -145,7 +145,7 @@ defmodule BldgServerWeb.ResidentController do
   end
 
   # SAY action
-  def act(conn, %{"resident_email" => email, "action_type" => "SAY", "say_speaker" => _speaker, "say_text" => _text, "say_time" => _msg_time, "say_flr" => _flr, "say_location" => _location, "say_mimetype" => _msg_mimetype, "say_recipient" => _recipient} = msg) do
+  def act(conn, %{"resident_email" => email, "action_type" => "SAY", "say_speaker" => _speaker, "say_text" => _text, "say_flr" => _flr, "say_location" => _location, "say_mimetype" => _msg_mimetype, "say_recipient" => _recipient} = msg) do
     resident = Residents.get_resident_by_email!(email)
 
     with {:ok, %Resident{} = upd_rsdt} <- Residents.say(resident, msg) do

--- a/bldg_server/lib/bldg_server_web/router.ex
+++ b/bldg_server/lib/bldg_server_web/router.ex
@@ -20,6 +20,7 @@ defmodule BldgServerWeb.Router do
     get "/roads/look/:flr", RoadController, :look
     post "/batteries/attach", BatteryController, :attach
     post "/batteries/detach", BatteryController, :detach
+    post "/batteries/act", BldgController, :act
 
     resources "/bldgs", BldgController, except: [:new, :edit], param: "address"
     resources "/residents", ResidentController, except: [:new, :edit]

--- a/bldg_server/lib/bldg_server_web/router.ex
+++ b/bldg_server/lib/bldg_server_web/router.ex
@@ -18,9 +18,12 @@ defmodule BldgServerWeb.Router do
     get "/residents/look/:flr", ResidentController, :look
     post "/residents/act", ResidentController, :act
     get "/roads/look/:flr", RoadController, :look
-    
+    post "/batteries/attach", BatteryController, :attach
+    post "/batteries/detach", BatteryController, :detach
+
     resources "/bldgs", BldgController, except: [:new, :edit], param: "address"
     resources "/residents", ResidentController, except: [:new, :edit]
     resources "/roads", RoadController, except: [:new, :edit]
+    resources "/batteries", BatteryController, except: [:new, :edit, :create], param: "bldg_address"
   end
 end

--- a/bldg_server/lib/bldg_server_web/views/battery_view.ex
+++ b/bldg_server/lib/bldg_server_web/views/battery_view.ex
@@ -1,0 +1,24 @@
+defmodule BldgServerWeb.BatteryView do
+  use BldgServerWeb, :view
+  alias BldgServerWeb.BatteryView
+
+  def render("index.json", %{batteries: batteries}) do
+    %{data: render_many(batteries, BatteryView, "battery.json")}
+  end
+
+  def render("show.json", %{battery: battery}) do
+    %{data: render_one(battery, BatteryView, "battery.json")}
+  end
+
+  def render("battery.json", %{battery: battery}) do
+    %{id: battery.id,
+      bldg_address: battery.bldg_address,
+      flr: battery.flr,
+      callback_url: battery.callback_url,
+      is_attached: battery.is_attached,
+      direct_only: battery.direct_only,
+      battery_type: battery.battery_type,
+      battery_version: battery.battery_version,
+      battery_vendor: battery.battery_vendor}
+  end
+end

--- a/bldg_server/lib/bldg_server_web/views/battery_view.ex
+++ b/bldg_server/lib/bldg_server_web/views/battery_view.ex
@@ -12,7 +12,7 @@ defmodule BldgServerWeb.BatteryView do
 
   def render("battery.json", %{battery: battery}) do
     %{id: battery.id,
-      bldg_address: battery.bldg_address,
+      bldg_url: battery.bldg_url,
       flr: battery.flr,
       callback_url: battery.callback_url,
       is_attached: battery.is_attached,

--- a/bldg_server/lib/bldg_server_web/views/bldg_view.ex
+++ b/bldg_server/lib/bldg_server_web/views/bldg_view.ex
@@ -34,6 +34,7 @@ defmodule BldgServerWeb.BldgView do
       summary: bldg.summary,
       picture_url: bldg.picture_url,
       owners: bldg.owners,
+      previous_messages: bldg.previous_messages,
       data: bldg.data}
   end
 end

--- a/bldg_server/lib/bldg_server_web/views/bldg_view.ex
+++ b/bldg_server/lib/bldg_server_web/views/bldg_view.ex
@@ -35,6 +35,7 @@ defmodule BldgServerWeb.BldgView do
       picture_url: bldg.picture_url,
       owners: bldg.owners,
       previous_messages: bldg.previous_messages,
+      updated_at: bldg.updated_at,
       data: bldg.data}
   end
 end

--- a/bldg_server/lib/bldg_server_web/views/resident_view.ex
+++ b/bldg_server/lib/bldg_server_web/views/resident_view.ex
@@ -30,6 +30,8 @@ defmodule BldgServerWeb.ResidentView do
       previous_messages: resident.previous_messages,
       other_attributes: resident.other_attributes,
       session_id: resident.session_id,
-      last_login_at: resident.last_login_at}
+      last_login_at: resident.last_login_at,
+      updated_at: resident.updated_at
+    }
   end
 end

--- a/bldg_server/mix.exs
+++ b/bldg_server/mix.exs
@@ -4,7 +4,7 @@ defmodule BldgServer.MixProject do
   def project do
     [
       app: :bldg_server,
-      version: "0.5.4",
+      version: "0.5.6",
       elixir: "~> 1.5",
       elixirc_paths: elixirc_paths(Mix.env()),
       compilers: [:phoenix, :gettext] ++ Mix.compilers(),

--- a/bldg_server/priv/repo/migrations/20210506022711_create_batteries.exs
+++ b/bldg_server/priv/repo/migrations/20210506022711_create_batteries.exs
@@ -1,0 +1,19 @@
+defmodule BldgServer.Repo.Migrations.CreateBatteries do
+  use Ecto.Migration
+
+  def change do
+    create table(:batteries) do
+      add :bldg_address, :string, null: false
+      add :flr, :string, null: false
+      add :callback_url, :string, null: false
+      add :is_attached, :boolean, default: true, null: false
+      add :direct_only, :boolean, default: false, null: false
+      add :battery_type, :string
+      add :battery_version, :string
+      add :battery_vendor, :string
+
+      timestamps()
+    end
+
+  end
+end

--- a/bldg_server/priv/repo/migrations/20210604133926_single_battery_in_bldg.exs
+++ b/bldg_server/priv/repo/migrations/20210604133926_single_battery_in_bldg.exs
@@ -1,0 +1,7 @@
+defmodule BldgServer.Repo.Migrations.SingleBatteryInBldg do
+  use Ecto.Migration
+
+  def change do
+    create unique_index(:batteries, [:bldg_address, :is_attached], name: :single_attached_battery_in_bldg)
+  end
+end

--- a/bldg_server/priv/repo/migrations/20221010222803_add_previous_messages_to_bldgs.exs
+++ b/bldg_server/priv/repo/migrations/20221010222803_add_previous_messages_to_bldgs.exs
@@ -1,0 +1,9 @@
+defmodule BldgServer.Repo.Migrations.AddPreviousMessagesToBldgs do
+  use Ecto.Migration
+
+  def change do
+    alter table("bldgs") do
+      add :previous_messages, {:array, :text}
+    end
+  end
+end

--- a/bldg_server/test/bldg_server/batteries_test.exs
+++ b/bldg_server/test/bldg_server/batteries_test.exs
@@ -1,0 +1,78 @@
+defmodule BldgServer.BatteriesTest do
+  use BldgServer.DataCase
+
+  alias BldgServer.Batteries
+
+  describe "batteries" do
+    alias BldgServer.Batteries.Battery
+
+    @valid_attrs %{battery_type: "some battery_type", battery_vendor: "some battery_vendor", battery_version: "some battery_version", bldg_address: "some bldg_address", callback_url: "some callback_url", direct_only: true, flr: "some flr", is_attached: true}
+    @update_attrs %{battery_type: "some updated battery_type", battery_vendor: "some updated battery_vendor", battery_version: "some updated battery_version", bldg_address: "some updated bldg_address", callback_url: "some updated callback_url", direct_only: false, flr: "some updated flr", is_attached: false}
+    @invalid_attrs %{battery_type: nil, battery_vendor: nil, battery_version: nil, bldg_address: nil, callback_url: nil, direct_only: nil, flr: nil, is_attached: nil}
+
+    def battery_fixture(attrs \\ %{}) do
+      {:ok, battery} =
+        attrs
+        |> Enum.into(@valid_attrs)
+        |> Batteries.create_battery()
+
+      battery
+    end
+
+    test "list_batteries/0 returns all batteries" do
+      battery = battery_fixture()
+      assert Batteries.list_batteries() == [battery]
+    end
+
+    test "get_battery!/1 returns the battery with given id" do
+      battery = battery_fixture()
+      assert Batteries.get_battery!(battery.id) == battery
+    end
+
+    test "create_battery/1 with valid data creates a battery" do
+      assert {:ok, %Battery{} = battery} = Batteries.create_battery(@valid_attrs)
+      assert battery.battery_type == "some battery_type"
+      assert battery.battery_vendor == "some battery_vendor"
+      assert battery.battery_version == "some battery_version"
+      assert battery.bldg_address == "some bldg_address"
+      assert battery.callback_url == "some callback_url"
+      assert battery.direct_only == true
+      assert battery.flr == "some flr"
+      assert battery.is_attached == true
+    end
+
+    test "create_battery/1 with invalid data returns error changeset" do
+      assert {:error, %Ecto.Changeset{}} = Batteries.create_battery(@invalid_attrs)
+    end
+
+    test "update_battery/2 with valid data updates the battery" do
+      battery = battery_fixture()
+      assert {:ok, %Battery{} = battery} = Batteries.update_battery(battery, @update_attrs)
+      assert battery.battery_type == "some updated battery_type"
+      assert battery.battery_vendor == "some updated battery_vendor"
+      assert battery.battery_version == "some updated battery_version"
+      assert battery.bldg_address == "some updated bldg_address"
+      assert battery.callback_url == "some updated callback_url"
+      assert battery.direct_only == false
+      assert battery.flr == "some updated flr"
+      assert battery.is_attached == false
+    end
+
+    test "update_battery/2 with invalid data returns error changeset" do
+      battery = battery_fixture()
+      assert {:error, %Ecto.Changeset{}} = Batteries.update_battery(battery, @invalid_attrs)
+      assert battery == Batteries.get_battery!(battery.id)
+    end
+
+    test "delete_battery/1 deletes the battery" do
+      battery = battery_fixture()
+      assert {:ok, %Battery{}} = Batteries.delete_battery(battery)
+      assert_raise Ecto.NoResultsError, fn -> Batteries.get_battery!(battery.id) end
+    end
+
+    test "change_battery/1 returns a battery changeset" do
+      battery = battery_fixture()
+      assert %Ecto.Changeset{} = Batteries.change_battery(battery)
+    end
+  end
+end

--- a/bldg_server/test/bldg_server_web/controllers/battery_controller_test.exs
+++ b/bldg_server/test/bldg_server_web/controllers/battery_controller_test.exs
@@ -1,0 +1,116 @@
+defmodule BldgServerWeb.BatteryControllerTest do
+  use BldgServerWeb.ConnCase
+
+  alias BldgServer.Batteries
+  alias BldgServer.Batteries.Battery
+
+  @create_attrs %{
+    battery_type: "some battery_type",
+    battery_vendor: "some battery_vendor",
+    battery_version: "some battery_version",
+    bldg_address: "some bldg_address",
+    callback_url: "some callback_url",
+    direct_only: true,
+    flr: "some flr",
+    is_attached: true
+  }
+  @update_attrs %{
+    battery_type: "some updated battery_type",
+    battery_vendor: "some updated battery_vendor",
+    battery_version: "some updated battery_version",
+    bldg_address: "some updated bldg_address",
+    callback_url: "some updated callback_url",
+    direct_only: false,
+    flr: "some updated flr",
+    is_attached: false
+  }
+  @invalid_attrs %{battery_type: nil, battery_vendor: nil, battery_version: nil, bldg_address: nil, callback_url: nil, direct_only: nil, flr: nil, is_attached: nil}
+
+  def fixture(:battery) do
+    {:ok, battery} = Batteries.create_battery(@create_attrs)
+    battery
+  end
+
+  setup %{conn: conn} do
+    {:ok, conn: put_req_header(conn, "accept", "application/json")}
+  end
+
+  describe "index" do
+    test "lists all batteries", %{conn: conn} do
+      conn = get(conn, Routes.battery_path(conn, :index))
+      assert json_response(conn, 200)["data"] == []
+    end
+  end
+
+  describe "create battery" do
+    test "renders battery when data is valid", %{conn: conn} do
+      conn = post(conn, Routes.battery_path(conn, :create), battery: @create_attrs)
+      assert %{"id" => id} = json_response(conn, 201)["data"]
+
+      conn = get(conn, Routes.battery_path(conn, :show, id))
+
+      assert %{
+               "id" => id,
+               "battery_type" => "some battery_type",
+               "battery_vendor" => "some battery_vendor",
+               "battery_version" => "some battery_version",
+               "bldg_address" => "some bldg_address",
+               "callback_url" => "some callback_url",
+               "direct_only" => true,
+               "flr" => "some flr",
+               "is_attached" => true
+             } = json_response(conn, 200)["data"]
+    end
+
+    test "renders errors when data is invalid", %{conn: conn} do
+      conn = post(conn, Routes.battery_path(conn, :create), battery: @invalid_attrs)
+      assert json_response(conn, 422)["errors"] != %{}
+    end
+  end
+
+  describe "update battery" do
+    setup [:create_battery]
+
+    test "renders battery when data is valid", %{conn: conn, battery: %Battery{id: id} = battery} do
+      conn = put(conn, Routes.battery_path(conn, :update, battery), battery: @update_attrs)
+      assert %{"id" => ^id} = json_response(conn, 200)["data"]
+
+      conn = get(conn, Routes.battery_path(conn, :show, id))
+
+      assert %{
+               "id" => id,
+               "battery_type" => "some updated battery_type",
+               "battery_vendor" => "some updated battery_vendor",
+               "battery_version" => "some updated battery_version",
+               "bldg_address" => "some updated bldg_address",
+               "callback_url" => "some updated callback_url",
+               "direct_only" => false,
+               "flr" => "some updated flr",
+               "is_attached" => false
+             } = json_response(conn, 200)["data"]
+    end
+
+    test "renders errors when data is invalid", %{conn: conn, battery: battery} do
+      conn = put(conn, Routes.battery_path(conn, :update, battery), battery: @invalid_attrs)
+      assert json_response(conn, 422)["errors"] != %{}
+    end
+  end
+
+  describe "delete battery" do
+    setup [:create_battery]
+
+    test "deletes chosen battery", %{conn: conn, battery: battery} do
+      conn = delete(conn, Routes.battery_path(conn, :delete, battery))
+      assert response(conn, 204)
+
+      assert_error_sent 404, fn ->
+        get(conn, Routes.battery_path(conn, :show, battery))
+      end
+    end
+  end
+
+  defp create_battery(_) do
+    battery = fixture(:battery)
+    {:ok, battery: battery}
+  end
+end


### PR DESCRIPTION
## Why
Bldgs sometimes need to have behavior, e.g., an assistant bot that automates creating & organizing objects in a bldg. Batteries enable adding a behavior to a bldg.

## What
* A battery is a web service that attaches to a bldg, by calling the `attach` API of the blag-server
* It then receives chat messages from the bldg-server, that were sent inside the bldg flr
* It may react to these chat messages, by calling a blog-server API, such as `act`

Note: only messages starting with `/` are currently sent to the batteries

See example battery [here](https://github.com/WebWideMatrix/battery_examples)

## Left to do
* Secure the battery access by checking that the battery owner has access rights in the bldg, & sending an email to the battery owner & ask to approve the attachment