### PR TITLE
batteries should connect based on bldg-url

### DIFF
--- a/bldg_server/priv/repo/migrations/20221011213434_change_battery_to_use_bldg_url.exs
+++ b/bldg_server/priv/repo/migrations/20221011213434_change_battery_to_use_bldg_url.exs
@@ -1,0 +1,7 @@
+defmodule BldgServer.Repo.Migrations.ChangeBatteryToUseBldgUrl do
+  use Ecto.Migration
+
+  def change do
+    rename table(:batteries), :bldg_address, to: :bldg_url
+  end
+end


### PR DESCRIPTION
## Why
Batteries should connect to a bldg based on its `bldg-url`, rather than `blog-address`, since the bldg may move (especially an assistant), which will change its address.

## What
Batteries table now has a `bldg_url` field to refer to the bldg the battery attaches to, instead of the `bldg_address` field